### PR TITLE
Update headers submodule name to godot-headers

### DIFF
--- a/.github/workflows/all_builds.yml
+++ b/.github/workflows/all_builds.yml
@@ -392,9 +392,9 @@ jobs:
 
       - name: Download Godot Engine
         run: |
-          wget https://downloads.tuxfamily.org/godotengine/${{env.GODOT_VERSION}}/Godot_v${{env.GODOT_VERSION}}-stable_osx.64.zip
-          unzip Godot_v${{env.GODOT_VERSION}}-stable_osx.64.zip
-          rm Godot_v${{env.GODOT_VERSION}}-stable_osx.64.zip
+          wget https://downloads.tuxfamily.org/godotengine/${{env.GODOT_VERSION}}/Godot_v${{env.GODOT_VERSION}}-stable_osx.universal.zip
+          unzip Godot_v${{env.GODOT_VERSION}}-stable_osx.universal.zip
+          rm Godot_v${{env.GODOT_VERSION}}-stable_osx.universal.zip
       - name: Download OSX binary
         uses: actions/download-artifact@v2
         with:

--- a/Android.mk
+++ b/Android.mk
@@ -41,7 +41,7 @@ fmod-core-prebuilt \
 fmod-studio-prebuilt
 
 LOCAL_C_INCLUDES := \
-../godot-cpp/godot_headers \
+../godot-cpp/godot-headers \
 ../godot-cpp/include/ \
 ../godot-cpp/include/core \
 ../godot-cpp/include/gen \

--- a/SConstruct
+++ b/SConstruct
@@ -178,7 +178,7 @@ if host_platform == 'windows':
     opts.Update(env)
 
 if env["headers_dir"] == 'default':
-    env["headers_dir"] = os.environ.get("GODOT_HEADERS", env["cpp_bindings_dir"] + "godot_headers/")
+    env["headers_dir"] = os.environ.get("GODOT_HEADERS", env["cpp_bindings_dir"] + "godot-headers/")
 
 if env['bits'] == 'default':
     env['bits'] = '64' if is64 else '32'
@@ -232,7 +232,7 @@ elif env['platform'] == 'osx':
     ])
 
     if env['target'] == 'debug':
-        env.Append(CCFLAGS=['-Og'])
+        env.Append(CCFLAGS=['-Og', 'g'])
     elif env['target'] == 'release':
         env.Append(CCFLAGS=['-O3'])
 
@@ -269,7 +269,7 @@ elif env['platform'] == 'ios':
     ])
 
     if env['target'] == 'debug':
-        env.Append(CCFLAGS=['-Og'])
+        env.Append(CCFLAGS=['-Og', '-g'])
     elif env['target'] == 'release':
         env.Append(CCFLAGS=['-O3'])
 


### PR DESCRIPTION
This updates the name of the `godot_headers` submodule to the new `godot-headers`

I'm still having some minor issues with GUT, so best to wait until I fix those:
![image](https://user-images.githubusercontent.com/42484461/138554143-a9dcac61-c3b5-4281-813c-77ce4d245873.png)
