### PR TITLE
Fix 2D rotation

### DIFF
--- a/demo/project.godot
+++ b/demo/project.godot
@@ -135,12 +135,12 @@ lock_listener={
 }
 rotate_left={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194319,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 rotate_right={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194321,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 kill_event={

--- a/src/helpers/maths.h
+++ b/src/helpers/maths.h
@@ -44,19 +44,19 @@ namespace godot {
 
     static inline FMOD_3D_ATTRIBUTES get_3d_attributes_from_transform2d(const Transform2D& transform, const Vector2& velocity, const float distanceScale) {
         Vector2 posVector = transform.get_origin() / distanceScale;
-        Vector3 pos(posVector.x, 0.0f, posVector.y);
+        Vector3 pos(-posVector.x, 0.0f, posVector.y);
         Vector3 up(0, 1, 0);
-        Vector3 forward = Vector3(transform.columns[1].x, 0, transform.columns[1].y).normalized();
-        Vector3 vel(velocity.x, 0, velocity.y);
+        Vector3 forward = Vector3(-transform.columns[1].x, 0, transform.columns[1].y).normalized();
+        Vector3 vel(-velocity.x, 0, velocity.y);
         const FMOD_VECTOR& posFmodVector = get_fmod_vector_from_3d(pos);
         return get_3d_attributes(posFmodVector, get_fmod_vector_from_3d(up), get_fmod_vector_from_3d(forward), get_fmod_vector_from_3d(vel));
     }
 
     static inline FMOD_3D_ATTRIBUTES get_3d_attributes_from_transform2d(const Transform2D& transform, const float distanceScale) {
         Vector2 posVector = transform.get_origin() / distanceScale;
-        Vector3 pos(posVector.x, 0.0f, posVector.y);
+        Vector3 pos(-posVector.x, 0.0f, posVector.y);
         Vector3 up(0, 1, 0);
-        Vector3 forward = Vector3(transform.columns[1].x, 0, transform.columns[1].y).normalized();
+        Vector3 forward = Vector3(-transform.columns[1].x, 0, transform.columns[1].y).normalized();
         Vector3 vel(0, 0, 0);
         const FMOD_VECTOR& posFmodVector = get_fmod_vector_from_3d(pos);
         return get_3d_attributes(posFmodVector, get_fmod_vector_from_3d(up), get_fmod_vector_from_3d(forward), get_fmod_vector_from_3d(vel));
@@ -75,10 +75,10 @@ namespace godot {
 
     static inline Transform2D get_transform2d_from_3d_attributes(FMOD_3D_ATTRIBUTES& attr, const float distanceScale) {
         Transform2D transform;
-        transform.set_origin(Vector2(attr.position.x, attr.position.z) * distanceScale);
-        const Vector2& forward = Vector2(attr.forward.x, attr.forward.z);
+        transform.set_origin(Vector2(-attr.position.x, attr.position.z) * distanceScale);
+        const Vector2& forward = Vector2(-attr.forward.x, attr.forward.z);
         transform.columns[1] = forward;
-        transform.columns[0] = Vector2(forward.y, -forward.x);
+        transform.columns[0] = Vector2(forward.y, forward.x);
         return transform;
     }
 
@@ -87,7 +87,7 @@ namespace godot {
     }
 
     static inline Vector2 get_velocity2d_from_3d_attributes(FMOD_3D_ATTRIBUTES& attr, const float distanceScale) {
-        return {attr.velocity.x, attr.velocity.z};
+        return {-attr.velocity.x, attr.velocity.z};
     }
 
 }// namespace godot


### PR DESCRIPTION
2D is a simple matter, we just have to (I hope) negate the values on X.
I added back the ability to rotate the listener in the 2D demos so we can make sure we hear the sound in the right direction when not facing upward (use the left and right arrow).