### PR TITLE
Fix OneShot system.

### DIFF
--- a/demo/high_level_2D/ChangeColor.gd
+++ b/demo/high_level_2D/ChangeColor.gd
@@ -5,21 +5,21 @@ var icon: Sprite2D
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	body_entered.connect(enter)
-	body_exited.connect(leave)
-	$FmodEventEmitter2D.paused = true
+    body_entered.connect(enter)
+    body_exited.connect(leave)
+    $FmodEventEmitter2D.paused = true
 
 # warning-ignore:unused_argument
 func enter(_area):
-	print("enter")
-	
-	$FmodEventEmitter2D.paused = false
-	
+    print("enter")
+    
+    $FmodEventEmitter2D.paused = false
+    
 # warning-ignore:unused_argument
 func leave(_area):
-	print("leave")
-	$FmodEventEmitter2D.paused = true
+    print("leave")
+    $FmodEventEmitter2D.paused = true
 
 # warning-ignore:unused_argument
 func change_color(_dict: Dictionary):
-	$icon.self_modulate = Color(randf_range(0,1), randf_range(0,1), randf_range(0,1), 1)
+    $icon.self_modulate = Color(randf_range(0,1), randf_range(0,1), randf_range(0,1), 1)

--- a/demo/high_level_2D/FmodNodesTest.tscn
+++ b/demo/high_level_2D/FmodNodesTest.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=3 uid="uid://dl6g18ybwc83t"]
+[gd_scene load_steps=12 format=3 uid="uid://dl6g18ybwc83t"]
 
 [ext_resource type="Script" path="res://high_level_2D/sin_move.gd" id="1_2lkrj"]
 [ext_resource type="Script" path="res://high_level_2D/Emitter.gd" id="2_5cntr"]
@@ -6,6 +6,7 @@
 [ext_resource type="Script" path="res://high_level_2D/Kinematic.gd" id="3_dlbku"]
 [ext_resource type="Script" path="res://high_level_2D/ChangeColor.gd" id="5_5p5kb"]
 [ext_resource type="Script" path="res://low_level_2D/EnterAndLeave.gd" id="5_jxvuy"]
+[ext_resource type="PackedScene" uid="uid://glfbseq2tmgg" path="res://high_level_2D/footstep.tscn" id="5_usogy"]
 [ext_resource type="Script" path="res://low_level_2D/EnterandLeave2.gd" id="7_c28gt"]
 
 [sub_resource type="RectangleShape2D" id="1"]
@@ -69,6 +70,7 @@ texture = ExtResource("2_llv2n")
 [node name="Listener" type="CharacterBody2D" parent="FmodBankLoader"]
 position = Vector2(500, 150)
 script = ExtResource("3_dlbku")
+footstep_scene = ExtResource("5_usogy")
 
 [node name="FmodListener2D" type="FmodListener2D" parent="FmodBankLoader/Listener"]
 

--- a/demo/high_level_2D/Kinematic.gd
+++ b/demo/high_level_2D/Kinematic.gd
@@ -1,27 +1,35 @@
 extends CharacterBody2D
 
+var distance_traveled := 0
+@export var footstep_scene: PackedScene
+
 func _process(delta):
-	var direction: Vector2 = Vector2(0,0)
-	var rotation_dir = 0
-	if Input.is_action_pressed("right"):
-		direction.x += 1
-	if Input.is_action_pressed("left"):
-		direction.x -= 1
-	if Input.is_action_pressed("up"):
-		direction.y -= 1
-	if Input.is_action_pressed("down"):
-		direction.y += 1
-	if Input.is_action_pressed("rotate_right"):
-		rotation_dir = 1
-	if Input.is_action_pressed("rotate_left"):
-		rotation_dir = -1
-	direction = direction.normalized()
-	direction.x = direction.x * delta * 200
-	direction.y = direction.y * delta * 200
-	self.position += direction
-	self.rotate(rotation_dir * delta * 5)
-	if Input.is_action_pressed("lock_listener"):
-		$FmodListener2D.is_locked = !$FmodListener2D.is_locked
-	elif Input.is_action_pressed("kill"):
-		self.queue_free()
+    var direction: Vector2 = Vector2(0,0)
+    var rotation_dir = 0
+    if Input.is_action_pressed("right"):
+        direction.x += 1
+    if Input.is_action_pressed("left"):
+        direction.x -= 1
+    if Input.is_action_pressed("up"):
+        direction.y -= 1
+    if Input.is_action_pressed("down"):
+        direction.y += 1
+    if Input.is_action_pressed("rotate_right"):
+        rotation_dir = 1
+    if Input.is_action_pressed("rotate_left"):
+        rotation_dir = -1
+    if direction != Vector2(0,0):
+        distance_traveled += delta * 200
+        if distance_traveled >= 35:
+            distance_traveled = 0
+            add_child(footstep_scene.instantiate())
+    direction = direction.normalized()
+    direction.x = direction.x * delta * 200
+    direction.y = direction.y * delta * 200
+    self.position += direction
+    self.rotate(rotation_dir * delta * 5)
+    if Input.is_action_pressed("lock_listener"):
+        $FmodListener2D.is_locked = !$FmodListener2D.is_locked
+    elif Input.is_action_pressed("kill"):
+        self.queue_free()
 

--- a/demo/low_level_2D/FmodTest.gd
+++ b/demo/low_level_2D/FmodTest.gd
@@ -11,4 +11,6 @@ func _enter_tree():
     FmodServer.load_bank("res://assets/Banks/Music.bank", FmodServer.FMOD_STUDIO_LOAD_BANK_NORMAL)
 # warning-ignore:return_value_discarded
     FmodServer.load_bank("res://assets/Banks/Vehicles.bank", FmodServer.FMOD_STUDIO_LOAD_BANK_NORMAL)
+# warning-ignore:return_value_discarded
+    FmodServer.load_bank("res://assets/Banks/SFX.bank", FmodServer.FMOD_STUDIO_LOAD_BANK_NORMAL)
     print("Fmod initialised.")

--- a/demo/low_level_2D/Listener.gd
+++ b/demo/low_level_2D/Listener.gd
@@ -1,34 +1,42 @@
 extends CharacterBody2D
 
+var distance_traveled := 0
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	# register listener
-	FmodServer.add_listener(0, self)
-	print("Listener set.")
-	return
-	
+    # register listener
+    FmodServer.add_listener(0, self)
+    print("Listener set.")
+    return
+    
 func _process(delta):
-	var direction: Vector2 = Vector2(0,0)
-	var rotation_dir = 0
-	if Input.is_action_pressed("right"):
-		direction.x += 1
-	if Input.is_action_pressed("left"):
-		direction.x -= 1
-	if Input.is_action_pressed("up"):
-		direction.y -= 1
-	if Input.is_action_pressed("down"):
-		direction.y += 1
-	if Input.is_action_pressed("rotate_right"):
-		rotation_dir = 1
-	if Input.is_action_pressed("rotate_left"):
-		rotation_dir = -1
-	direction = direction.normalized()
-	direction.x = direction.x * delta * 200
-	direction.y = direction.y * delta * 200
-	self.position += direction
-	self.rotate(rotation_dir * delta * 5)
-	if Input.is_action_pressed("lock_listener"):
-		FmodServer.set_listener_lock(0, !FmodServer.get_listener_lock(0))
-	elif Input.is_action_pressed("kill"):
-		self.queue_free()
+    var direction: Vector2 = Vector2(0,0)
+    var rotation_dir = 0
+    if Input.is_action_pressed("right"):
+        direction.x += 1
+    if Input.is_action_pressed("left"):
+        direction.x -= 1
+    if Input.is_action_pressed("up"):
+        direction.y -= 1
+    if Input.is_action_pressed("down"):
+        direction.y += 1
+    if Input.is_action_pressed("rotate_right"):
+        rotation_dir = 1
+    if Input.is_action_pressed("rotate_left"):
+        rotation_dir = -1
+    if direction != Vector2(0,0):
+        distance_traveled += delta * 200
+        if distance_traveled >= 35:
+            distance_traveled = 0
+            FmodServer.play_one_shot("event:/Character/Player Footsteps")
+    direction = direction.normalized()
+    direction.x = direction.x * delta * 200
+    direction.y = direction.y * delta * 200
+
+    self.position += direction
+    self.rotate(rotation_dir * delta * 5)
+    if Input.is_action_pressed("lock_listener"):
+        FmodServer.set_listener_lock(0, !FmodServer.get_listener_lock(0))
+    elif Input.is_action_pressed("kill"):
+        self.queue_free()
 

--- a/src/fmod_server.cpp
+++ b/src/fmod_server.cpp
@@ -212,19 +212,21 @@ void FmodServer::update() {
 
     callback_mutex->unlock();
 
-    for (OneShot* oneShot : oneShots) {
+
+    Vector<OneShot*> one_shots_copy = oneShots;
+    for (OneShot* oneShot : one_shots_copy) {
 
         if (!oneShot->instance->is_valid() || is_dead(oneShot->gameObj)) {
-            //We release one-shots as soon as they are started, the event becomes invalid as soon as it ends
+            //We release one-shots when they are started, the event becomes invalid as soon as it ends
             oneShots.erase(oneShot);
             delete oneShot;
             continue;
         }
-
-        if (Node* obj = oneShot->gameObj) { oneShot->instance->set_node_attributes(obj); }
+        oneShot->instance->set_node_attributes(oneShot->gameObj);
     }
 
-    for (const Ref<FmodEvent>& event : runningEvents) {
+    Vector<Ref<FmodEvent>> events_copy = runningEvents;
+    for (const Ref<FmodEvent>& event : events_copy) {
         if (!event->is_valid()) { runningEvents.erase(event); }
     }
 

--- a/src/fmod_server.cpp
+++ b/src/fmod_server.cpp
@@ -228,7 +228,7 @@ void FmodServer::update() {
             continue;
         }
 
-        if (oneShot->gameObj) { oneShot->instance->set_node_attributes(oneShot->gameObj); }
+        if (Node* obj = oneShot->gameObj) { oneShot->instance->set_node_attributes(obj); }
     }
 
     for (const Ref<FmodEvent>& event : runningEvents) {
@@ -587,6 +587,7 @@ Ref<FmodEventDescription> FmodServer::_get_event_description(const String& event
     bool found = cache->has_event_path(event_name);
     if (!found) {
         GODOT_LOG_WARNING("Event " + event_name + " can't be found. Check if the path is correct or the bank properly loaded.")
+        return {};
     }
 
     return cache->get_event(event_name);
@@ -597,6 +598,7 @@ Ref<FmodEventDescription> FmodServer::_get_event_description(const FMOD_GUID& gu
     if (!found) {
         String fmod_guid_string {fmod_guid_to_string(guid)};
         GODOT_LOG_WARNING("Event " + fmod_guid_string + " can't be found. Check if the path is correct or the bank properly loaded.")
+        return {};
     }
 
     return cache->get_event(guid);

--- a/src/fmod_server.cpp
+++ b/src/fmod_server.cpp
@@ -88,18 +88,30 @@ void FmodServer::_bind_methods() {
     ClassDB::bind_method(D_METHOD("create_event_instance_with_guid", "guid"), &FmodServer::create_event_instance_with_guid);
     ClassDB::bind_method(D_METHOD("create_event_instance", "eventPath"), &FmodServer::create_event_instance);
     ClassDB::bind_method(D_METHOD("create_event_instance_from_description", "eventPath"), &FmodServer::create_event_instance_from_description);
-    ClassDB::bind_method(D_METHOD("play_one_shot_using_guid", "guid", "game_obj"), &FmodServer::play_one_shot_using_guid);
-    ClassDB::bind_method(D_METHOD("play_one_shot", "event_name", "game_obj"), &FmodServer::play_one_shot);
-    ClassDB::bind_method(D_METHOD("play_one_shot_using_event_description", "event_description", "game_obj"), &FmodServer::play_one_shot_using_event_description);
-    ClassDB::bind_method(D_METHOD("play_one_shot_using_guid_with_params", "guid", "game_obj", "parameters"), &FmodServer::play_one_shot_using_guid_with_params);
-    ClassDB::bind_method(D_METHOD("play_one_shot_with_params", "event_name", "game_obj", "parameters"), &FmodServer::play_one_shot_with_params);
-    ClassDB::bind_method(D_METHOD("play_one_shot_using_event_description_with_params", "event_description", "game_obj", "parameters"), &FmodServer::play_one_shot_using_event_description_with_params);
+    ClassDB::bind_method(D_METHOD("play_one_shot_using_guid", "guid"), &FmodServer::play_one_shot_using_guid);
+    ClassDB::bind_method(D_METHOD("play_one_shot", "event_name"), &FmodServer::play_one_shot);
+    ClassDB::bind_method(D_METHOD("play_one_shot_using_event_description", "event_description"), &FmodServer::play_one_shot_using_event_description);
+    ClassDB::bind_method(D_METHOD("play_one_shot_using_guid_with_params", "guid", "parameters"), &FmodServer::play_one_shot_using_guid_with_params);
+    ClassDB::bind_method(D_METHOD("play_one_shot_with_params", "event_name", "parameters"), &FmodServer::play_one_shot_with_params);
+    ClassDB::bind_method(
+      D_METHOD("play_one_shot_using_event_description_with_params", "event_description", "parameters"),
+      &FmodServer::play_one_shot_using_event_description_with_params
+    );
     ClassDB::bind_method(D_METHOD("play_one_shot_using_guid_attached", "guid", "game_obj"), &FmodServer::play_one_shot_using_guid_attached);
     ClassDB::bind_method(D_METHOD("play_one_shot_attached", "event_name", "game_obj"), &FmodServer::play_one_shot_attached);
-    ClassDB::bind_method(D_METHOD("play_one_shot_using_event_description_attached", "event_description", "game_obj"), &FmodServer::play_one_shot_using_event_description_attached);
-    ClassDB::bind_method(D_METHOD("play_one_shot_using_guid_attached_with_params", "guid", "game_obj", "parameters"), &FmodServer::play_one_shot_using_guid_attached_with_params);
+    ClassDB::bind_method(
+      D_METHOD("play_one_shot_using_event_description_attached", "event_description", "game_obj"),
+      &FmodServer::play_one_shot_using_event_description_attached
+    );
+    ClassDB::bind_method(
+      D_METHOD("play_one_shot_using_guid_attached_with_params", "guid", "game_obj", "parameters"),
+      &FmodServer::play_one_shot_using_guid_attached_with_params
+    );
     ClassDB::bind_method(D_METHOD("play_one_shot_attached_with_params", "event_name", "game_obj", "parameters"), &FmodServer::play_one_shot_attached_with_params);
-    ClassDB::bind_method(D_METHOD("play_one_shot_using_event_description_attached_with_params", "event_description", "game_obj", "parameters"), &FmodServer::play_one_shot_using_event_description_attached_with_params);
+    ClassDB::bind_method(
+      D_METHOD("play_one_shot_using_event_description_attached_with_params", "event_description", "game_obj", "parameters"),
+      &FmodServer::play_one_shot_using_event_description_attached_with_params
+    );
     ClassDB::bind_method(D_METHOD("pause_all_events"), &FmodServer::pause_all_events);
     ClassDB::bind_method(D_METHOD("unpause_all_events"), &FmodServer::unpause_all_events);
     ClassDB::bind_method(D_METHOD("mute_all_events"), &FmodServer::mute_all_events);
@@ -148,13 +160,9 @@ void FmodServer::init(const Ref<FmodGeneralSettings>& p_settings) {
 
     FMOD_STUDIO_INITFLAGS studio_init_flags = FMOD_STUDIO_INIT_NORMAL;
 
-    if (p_settings->get_is_live_update_enabled()) {
-        studio_init_flags |= FMOD_STUDIO_INIT_LIVEUPDATE;
-    }
+    if (p_settings->get_is_live_update_enabled()) { studio_init_flags |= FMOD_STUDIO_INIT_LIVEUPDATE; }
 
-    if (p_settings->get_is_memory_tracking_enabled()) {
-        studio_init_flags |= FMOD_STUDIO_INIT_MEMORY_TRACKING;
-    }
+    if (p_settings->get_is_memory_tracking_enabled()) { studio_init_flags |= FMOD_STUDIO_INIT_MEMORY_TRACKING; }
 
     FMOD_INITFLAGS init_flags = FMOD_INIT_3D_RIGHTHANDED;
 
@@ -213,17 +221,17 @@ void FmodServer::update() {
         FMOD_STUDIO_PLAYBACK_STATE s;
         ERROR_CHECK(oneShot->instance->get_wrapped()->getPlaybackState(&s));
 
-        if (s == FMOD_STUDIO_PLAYBACK_STOPPED || is_dead(oneShot->gameObj)) {
+        if (s == FMOD_STUDIO_PLAYBACK_STOPPED || (oneShot->gameObj && is_dead(oneShot->gameObj))) {
             FMOD_STUDIO_STOP_MODE m = FMOD_STUDIO_STOP_IMMEDIATE;
             oneShot->instance->stop(m);
             oneShots.erase(oneShot);
             continue;
         }
 
-        oneShot->instance->set_node_attributes(oneShot->gameObj);
+        if (oneShot->gameObj) { oneShot->instance->set_node_attributes(oneShot->gameObj); }
     }
 
-    for (Ref<FmodEvent> event : runningEvents) {
+    for (const Ref<FmodEvent>& event : runningEvents) {
         if (!event->is_valid()) { runningEvents.erase(event); }
     }
 
@@ -269,9 +277,7 @@ void FmodServer::_set_listener_attributes() {
 }
 
 void FmodServer::shutdown() {
-    if (!isInitialized) {
-        return;
-    }
+    if (!isInitialized) { return; }
 
     isInitialized = false;
     isNotInitializedPrinted = false;
@@ -449,13 +455,11 @@ void FmodServer::set_software_format(const Ref<FmodSoftwareFormatSettings>& p_se
         ERROR_CHECK(FMOD::Studio::System::create(&system));
         ERROR_CHECK(system->getCoreSystem(&coreSystem));
     }
-    ERROR_CHECK(
-      coreSystem->setSoftwareFormat(
+    ERROR_CHECK(coreSystem->setSoftwareFormat(
       p_settings->get_sample_rate(),
       static_cast<FMOD_SPEAKERMODE>(p_settings->get_speaker_mode()),
       p_settings->get_raw_speakers_count()
-      )
-    );
+    ));
 }
 
 Ref<FmodBank> FmodServer::load_bank(const String& pathToBank, unsigned int flag) {
@@ -598,147 +602,64 @@ Ref<FmodEventDescription> FmodServer::_get_event_description(const FMOD_GUID& gu
     return cache->get_event(guid);
 }
 
-void FmodServer::play_one_shot_using_guid(const String& guid, Node* game_obj) {
-    return play_one_shot_using_guid_internal(string_to_fmod_guid(guid.utf8().get_data()), game_obj);
-}
-
-void FmodServer::play_one_shot_using_guid_internal(const FMOD_GUID& guid, godot::Node* game_obj) {
+void FmodServer::play_one_shot_using_guid(const String& guid) {
     EventIdentifier parameter {};
-    parameter.guid = guid;
-    return _play_one_shot<
-      EventIdentifierType::GUID,
-      false,
-      false,
-      Dictionary,
-      &FmodServer::_apply_parameter_dict_to_event
-    >(parameter, game_obj);
+    parameter.guid = string_to_fmod_guid(guid.utf8().get_data());
+    return _play_one_shot<EventIdentifierType::GUID, false>(parameter, nullptr);
 }
 
-void FmodServer::play_one_shot(const String& event_name, Node* game_obj) {
-    return _play_one_shot<
-      EventIdentifierType::PATH,
-      false,
-      false,
-      Dictionary,
-      &FmodServer::_apply_parameter_dict_to_event
-    >({event_name.utf8().get_data()}, game_obj);
+void FmodServer::play_one_shot(const String& event_name) {
+    return _play_one_shot<EventIdentifierType::PATH, false>({event_name.utf8().get_data()}, nullptr);
 }
 
-void FmodServer::play_one_shot_using_event_description(const Ref<FmodEventDescription>& event_description, Node* game_obj) {
+void FmodServer::play_one_shot_using_event_description(const Ref<FmodEventDescription>& event_description) {
     EventIdentifier parameter {};
     parameter.event_description = event_description.ptr();
-    return _play_one_shot<
-      EventIdentifierType::EVENT_DESCRIPTION,
-      false,
-      false,
-      Dictionary,
-      &FmodServer::_apply_parameter_dict_to_event
-    >(parameter, game_obj);
+    return _play_one_shot<EventIdentifierType::EVENT_DESCRIPTION, false>(parameter, nullptr);
 }
 
-void FmodServer::play_one_shot_using_guid_with_params(const String& guid, Node* game_obj, const Dictionary& parameters) {
-    return play_one_shot_using_guid_with_params_internal(string_to_fmod_guid(guid.utf8().get_data()), game_obj, parameters);
-}
-
-void FmodServer::play_one_shot_using_guid_with_params_internal(const FMOD_GUID& guid, godot::Node* game_obj, const godot::Dictionary& parameters) {
+void FmodServer::play_one_shot_using_guid_with_params(const String& guid, const Dictionary& parameters) {
     EventIdentifier parameter {};
-    parameter.guid = guid;
+    parameter.guid = string_to_fmod_guid(guid.utf8().get_data());
 
-    return _play_one_shot<
-      EventIdentifierType::GUID,
-      true,
-      false,
-      Dictionary,
-      &FmodServer::_apply_parameter_dict_to_event
-    >(parameter, game_obj, parameters);
+    return _play_one_shot<EventIdentifierType::GUID, true>(parameter, nullptr, parameters);
 }
 
-void FmodServer::play_one_shot_with_params(const String& event_name, Node* game_obj, const Dictionary& parameters) {
-    return _play_one_shot<
-      EventIdentifierType::PATH,
-      true,
-      false,
-      Dictionary,
-      &FmodServer::_apply_parameter_dict_to_event
-    >({event_name.utf8().get_data()}, game_obj, parameters);
+void FmodServer::play_one_shot_with_params(const String& event_name, const Dictionary& parameters) {
+    return _play_one_shot<EventIdentifierType::PATH, true>({event_name.utf8().get_data()}, nullptr, parameters);
 }
 
-void FmodServer::play_one_shot_using_event_description_with_params(const Ref<FmodEventDescription>& event_description, Node* game_obj, const Dictionary& parameters) {
+void FmodServer::play_one_shot_using_event_description_with_params(const Ref<FmodEventDescription>& event_description, const Dictionary& parameters) {
     EventIdentifier parameter {};
     parameter.event_description = event_description.ptr();
 
-    return _play_one_shot<
-      EventIdentifierType::EVENT_DESCRIPTION,
-      true,
-      false,
-      Dictionary,
-      &FmodServer::_apply_parameter_dict_to_event
-    >(parameter, game_obj, parameters);
+    return _play_one_shot<EventIdentifierType::EVENT_DESCRIPTION, true>(parameter, nullptr, parameters);
 }
 
 void FmodServer::play_one_shot_using_guid_attached(const String& guid, Node* game_obj) {
-    return play_one_shot_using_guid_attached_internal(string_to_fmod_guid(guid.utf8().get_data()), game_obj);
-}
-
-void FmodServer::play_one_shot_using_guid_attached_internal(const FMOD_GUID& guid, Node* game_obj) {
     EventIdentifier parameter {};
-    parameter.guid = guid;
-    return _play_one_shot<
-      EventIdentifierType::GUID,
-      false,
-      true,
-      Dictionary,
-      &FmodServer::_apply_parameter_dict_to_event
-    >(parameter, game_obj);
+    parameter.guid = string_to_fmod_guid(guid.utf8().get_data());
+    return _play_one_shot<EventIdentifierType::GUID, false>(parameter, game_obj);
 }
 
 void FmodServer::play_one_shot_attached(const String& event_name, Node* game_obj) {
-    return _play_one_shot<
-      EventIdentifierType::PATH,
-      false,
-      true,
-      Dictionary,
-      &FmodServer::_apply_parameter_dict_to_event
-    >({event_name.utf8().get_data()}, game_obj);
+    return _play_one_shot<EventIdentifierType::PATH, false>({event_name.utf8().get_data()}, game_obj);
 }
 
 void FmodServer::play_one_shot_using_event_description_attached(const Ref<FmodEventDescription>& event_description, Node* game_obj) {
     EventIdentifier parameter {};
     parameter.event_description = event_description.ptr();
-    return _play_one_shot<
-      EventIdentifierType::EVENT_DESCRIPTION,
-      false,
-      true,
-      Dictionary,
-      &FmodServer::_apply_parameter_dict_to_event
-    >(parameter, game_obj);
+    return _play_one_shot<EventIdentifierType::EVENT_DESCRIPTION, false>(parameter, game_obj);
 }
 
 void FmodServer::play_one_shot_using_guid_attached_with_params(const String& guid, Node* game_obj, const Dictionary& parameters) {
-    return play_one_shot_using_guid_attached_with_params_internal(string_to_fmod_guid(guid.utf8().get_data()), game_obj, parameters);
-}
-
-void FmodServer::play_one_shot_using_guid_attached_with_params_internal(const FMOD_GUID& guid, Node* game_obj, const Dictionary& parameters) {
     EventIdentifier parameter {};
-    parameter.guid = guid;
-
-    return _play_one_shot<
-      EventIdentifierType::GUID,
-      true,
-      true,
-      Dictionary,
-      &FmodServer::_apply_parameter_dict_to_event
-    >(parameter, game_obj, parameters);
+    parameter.guid = string_to_fmod_guid(guid.utf8().get_data());
+    return _play_one_shot<EventIdentifierType::GUID, true>(parameter, game_obj, parameters);
 }
 
 void FmodServer::play_one_shot_attached_with_params(const String& event_name, Node* game_obj, const Dictionary& parameters) {
-    return _play_one_shot<
-      EventIdentifierType::PATH,
-      true,
-      true,
-      Dictionary,
-      &FmodServer::_apply_parameter_dict_to_event
-    >({event_name.utf8().get_data()}, game_obj, parameters);
+    return _play_one_shot<EventIdentifierType::PATH, true>({event_name.utf8().get_data()}, game_obj, parameters);
 }
 
 void FmodServer::play_one_shot_using_event_description_attached_with_params(
@@ -749,13 +670,7 @@ void FmodServer::play_one_shot_using_event_description_attached_with_params(
     EventIdentifier parameter {};
     parameter.event_description = event_description.ptr();
 
-    return _play_one_shot<
-      EventIdentifierType::EVENT_DESCRIPTION,
-      true,
-      true,
-      Dictionary,
-      &FmodServer::_apply_parameter_dict_to_event
-    >(parameter, game_obj, parameters);
+    return _play_one_shot<EventIdentifierType::EVENT_DESCRIPTION, true>(parameter, game_obj, parameters);
 }
 
 void FmodServer::set_system_dsp_buffer_size(const Ref<FmodDspSettings>& p_settings) {
@@ -920,7 +835,7 @@ Ref<FmodEvent> FmodServer::_create_instance(const Ref<FmodEventDescription>& des
     Ref<FmodEvent> ref = FmodEvent::create_ref(eventInstance);
     if (ref.is_valid()) {
         runningEvents.push_back(ref);
-        if (is_one_shot || game_object) {
+        if (is_one_shot) {
             auto* oneShot = new OneShot();
             oneShot->gameObj = game_object;
             oneShots.push_back(oneShot);

--- a/src/fmod_server.h
+++ b/src/fmod_server.h
@@ -114,8 +114,6 @@ namespace godot {
         Ref<FmodEventDescription> _get_event_description(const String& event_name);
         Ref<FmodEventDescription> _get_event_description(const FMOD_GUID& guid);
 
-        template<EventIdentifierType parameter_type>
-        Ref<FmodEvent> _create_instance(const EventIdentifier& identifier, bool isOneShot, Node* gameObject);
         Ref<FmodEvent> _create_instance(const Ref<FmodEventDescription>& description, bool is_one_shot, Node* game_object);
 
         void _update_performance_data();
@@ -219,47 +217,44 @@ namespace godot {
 
         /* Helper methods */
     private:
-        template<EventIdentifierType parameter_type, bool with_params, bool is_attached, class TParameterCollection, void (* apply_parameters)(const Ref<FmodEvent>&, const TParameterCollection&)>
-        void _play_one_shot(const EventIdentifier& identifier, Node* game_obj, const TParameterCollection& parameters = TParameterCollection());
-
+        template<EventIdentifierType parameter_type>
+        Ref<FmodEventDescription> fetch_event_description(const EventIdentifier& identifier);
+        template<EventIdentifierType parameter_type, bool with_params>
+        void _play_one_shot(const EventIdentifier& identifier, Node* game_obj, const Dictionary& parameters = Dictionary());
         static void _apply_parameter_dict_to_event(const Ref<FmodEvent>& p_event, const Dictionary& parameters);
 
     public:
-        void play_one_shot_using_guid(const String& guid, Node* game_obj);
-        void play_one_shot_using_guid_internal(const FMOD_GUID& guid, Node* game_obj);
-        void play_one_shot(const String& event_name, Node* game_obj);
-        void play_one_shot_using_event_description(const Ref<FmodEventDescription>& event_description, Node* game_obj);
-        void play_one_shot_using_guid_with_params_internal(const FMOD_GUID& guid, Node* game_obj, const Dictionary& parameters);
-        void play_one_shot_using_guid_with_params(const String& guid, Node* game_obj, const Dictionary& parameters);
-        void play_one_shot_with_params(const String& event_name, Node* game_obj, const Dictionary& parameters);
-        void play_one_shot_using_event_description_with_params(const Ref<FmodEventDescription>& event_description, Node* game_obj, const Dictionary& parameters);
         template<class TParameter>
-        void play_one_shot_using_event_description_with_params_internal(const Ref<FmodEventDescription>& event_description, Node* game_obj, const List<TParameter>& parameters);
-        void play_one_shot_using_guid_attached(const String& guid, Node* game_obj);
-        void play_one_shot_using_guid_attached_internal(const FMOD_GUID& guid, Node* game_obj);
+        void apply_parameter_list_to_event(const Ref<FmodEvent>& p_event, const List<TParameter>& parameters);
+
+        void play_one_shot(const String& event_name);
+        void play_one_shot_with_params(const String& event_name, const Dictionary& parameters);
         void play_one_shot_attached(const String& event_name, Node* game_obj);
-        void play_one_shot_using_event_description_attached(const Ref<FmodEventDescription>& event_description, Node* game_obj);
-        void play_one_shot_using_guid_attached_with_params(const String& guid, Node* game_obj, const Dictionary& parameters);
-        void play_one_shot_using_guid_attached_with_params_internal(const FMOD_GUID& guid, Node* game_obj, const Dictionary& parameters);
         void play_one_shot_attached_with_params(const String& event_name, Node* game_obj, const Dictionary& parameters);
+
+        void play_one_shot_using_guid(const String& guid);
+        void play_one_shot_using_guid_with_params(const String& guid, const Dictionary& parameters);
+        void play_one_shot_using_guid_attached(const String& guid, Node* game_obj);
+        void play_one_shot_using_guid_attached_with_params(const String& guid, Node* game_obj, const Dictionary& parameters);
+
+        void play_one_shot_using_event_description(const Ref<FmodEventDescription>& event_description);
+        void play_one_shot_using_event_description_with_params(const Ref<FmodEventDescription>& event_description, const Dictionary& parameters);
+        void play_one_shot_using_event_description_attached(const Ref<FmodEventDescription>& event_description, Node* game_obj);
         void play_one_shot_using_event_description_attached_with_params(const Ref<FmodEventDescription>& event_description, Node* game_obj, const Dictionary& parameters);
-        template<class TParameterCollection>
-        void play_one_shot_using_event_description_attached_with_params_internal(const Ref<FmodEventDescription>& event_description, Node* game_obj, const List<TParameterCollection>& parameters);
+
         void pause_all_events();
         void unpause_all_events();
         void mute_all_events();
         void unmute_all_events();
         void wait_for_all_loads();
 
-        template<class TParameter>
-        static void apply_parameter_list_to_event(const Ref<FmodEvent>& p_event, const List<TParameter>& parameters);
-
     protected:
         static void _bind_methods();
     };
 
+
     template<FmodServer::EventIdentifierType parameter_type>
-    Ref<FmodEvent> FmodServer::_create_instance(const EventIdentifier& identifier, bool isOneShot, Node* gameObject) {
+    Ref<FmodEventDescription> FmodServer::fetch_event_description(const FmodServer::EventIdentifier& identifier){
         Ref<FmodEventDescription> desc;
         switch (parameter_type) {
             case PATH:
@@ -272,35 +267,40 @@ namespace godot {
                 desc = Ref<FmodEventDescription>(identifier.event_description);
                 break;
         }
-
-        return _create_instance(desc, isOneShot, gameObject);
+        return desc;
     }
 
     template<FmodServer::EventIdentifierType parameter_type>
     Ref<FmodEvent> FmodServer::_create_event_instance(const EventIdentifier& identifier) {
-        Ref<FmodEvent> ref = _create_instance<parameter_type>(identifier, false, nullptr);
+        Ref<FmodEvent> ref = _create_instance(fetch_event_description<parameter_type>(identifier), false, nullptr);
         ref->get_wrapped()->setUserData(ref.ptr());
         ref->set_distance_scale(distanceScale);
         return ref;
     }
 
-    template<FmodServer::EventIdentifierType parameter_type, bool with_params, bool is_attached, class TParameterCollection, void (* apply_parameters)(const Ref<FmodEvent>&, const TParameterCollection&)>
-    void FmodServer::_play_one_shot(const FmodServer::EventIdentifier& identifier, Node* game_obj, const TParameterCollection& parameters) {
-        if (is_attached && !is_fmod_valid(game_obj)) { return; }
+    template<FmodServer::EventIdentifierType parameter_type, bool with_params>
+    void FmodServer::_play_one_shot(const FmodServer::EventIdentifier& identifier, Node* game_obj, const Dictionary& parameters) {
+        Ref<FmodEventDescription> desc =  fetch_event_description<parameter_type>(identifier);
+        if (!desc->is_one_shot()){
+            GODOT_LOG_WARNING(desc->get_path() + " is not a OneShot event.")
+            return;
+        }
 
-        Ref<FmodEvent> ref = _create_instance<parameter_type>(
-          identifier,
+        if (game_obj && !is_fmod_valid(game_obj)) { return; }
+
+        Ref<FmodEvent> ref = _create_instance(
+         desc,
           true,
-          is_attached ? game_obj : nullptr
+          game_obj
         );
+
         if (!ref.is_valid()) { return; }
 
-        if (!is_attached) { ref->set_node_attributes(game_obj); }
+        if (game_obj) { ref->set_node_attributes(game_obj); }
 
         if (with_params) {
             // set the initial parameter values
-
-            apply_parameters(ref, parameters);
+            _apply_parameter_dict_to_event(ref, parameters);
         }
 
         ref->start();
@@ -317,34 +317,6 @@ namespace godot {
 
             p_event->set_parameter_by_name(*parameter.identifier.name, parameter.value);
         }
-    }
-
-    template<class TParameter>
-    void FmodServer::play_one_shot_using_event_description_with_params_internal(const Ref<FmodEventDescription>& event_description, Node* game_obj, const List<TParameter>& parameters) {
-        EventIdentifier parameter {};
-        parameter.event_description = event_description.ptr();
-
-        return _play_one_shot<
-          EventIdentifierType::EVENT_DESCRIPTION,
-          true,
-          false,
-          List<TParameter>, &FmodServer::apply_parameter_list_to_event>(parameter, game_obj, parameters);
-    }
-
-    template<class TParameter>
-    void FmodServer::play_one_shot_using_event_description_attached_with_params_internal(
-        const Ref<FmodEventDescription>& event_description,
-        Node* game_obj,
-        const List<TParameter>& parameters
-    ) {
-        EventIdentifier parameter {};
-        parameter.event_description = event_description.ptr();
-
-        return _play_one_shot<
-          EventIdentifierType::EVENT_DESCRIPTION,
-          true,
-          true,
-          List<TParameter>, &FmodServer::apply_parameter_list_to_event>(parameter, game_obj, parameters);
     }
 }// namespace godot
 

--- a/src/nodes/fmod_event_emitter_2d.cpp
+++ b/src/nodes/fmod_event_emitter_2d.cpp
@@ -25,3 +25,7 @@ void FmodEventEmitter2D::_exit_tree() {
 void FmodEventEmitter2D::_bind_methods() {
     FmodEventEmitter<FmodEventEmitter2D, Node2D>::_bind_methods();
 }
+
+void FmodEventEmitter2D::free_impl() {
+    queue_free();
+}

--- a/src/nodes/fmod_event_emitter_2d.h
+++ b/src/nodes/fmod_event_emitter_2d.h
@@ -13,6 +13,7 @@ namespace godot {
 
     private:
         void set_space_attribute_impl() const;
+        void free_impl();
 
     public:
         FmodEventEmitter2D() = default;

--- a/src/nodes/fmod_event_emitter_3d.cpp
+++ b/src/nodes/fmod_event_emitter_3d.cpp
@@ -25,3 +25,7 @@ void FmodEventEmitter3D::_exit_tree() {
 void FmodEventEmitter3D::_bind_methods() {
     FmodEventEmitter<FmodEventEmitter3D, Node3D>::_bind_methods();
 }
+
+void FmodEventEmitter3D::free_impl() {
+    queue_free();
+}

--- a/src/nodes/fmod_event_emitter_3d.h
+++ b/src/nodes/fmod_event_emitter_3d.h
@@ -12,6 +12,7 @@ namespace godot {
 
     private:
         void set_space_attribute_impl() const;
+        void free_impl();
 
     public:
         FmodEventEmitter3D() = default;


### PR DESCRIPTION
It had previously leftovers from the implementation in Godot 3.x (all events, not only oneshots were managed by the server) so I got rid of them.

A oneshot is actually not something up to the Godot user to decide, it's a property of the Fmod event itself, I removed its setter from the FmodEmitter node.

On top of that, only oneshot events can now be used as such. If not, a warning will be thrown. The reason for this is that one shot events can actually end (unlike the ones designed to loop), otherwise they would continue playing forever without any way to stop them. 

The methods to play a one shot won't ask for a Node if not attached.

Because emitters can no longer be set as oneshot, I replaced it with an auto release feature. When the event is done playing, the node will automatically free itself. This way, you can instantiate a scene containing a node with autoplay + autorelease to emulate oneshots.

When it comes to the implementation, I decided to simplify a bit. I removed a bunch of methods called "internal" as they were used only once and remove template parameters that were always the same.