### PR TITLE
Add verbose print

### DIFF
--- a/src/fmod_cache.cpp
+++ b/src/fmod_cache.cpp
@@ -47,7 +47,7 @@ Ref<FmodBank> FmodCache::add_bank(const String& bankPath, unsigned int flag) {
     ERROR_CHECK(system->loadBankFile(bankPath.utf8().get_data(), flag, &bank));
     if (!bank) { return {}; }
     Ref<FmodBank> ref = FmodBank::create_ref(bank, bankPath);
-    GODOT_LOG_INFO("FMOD Sound System: LOADING BANK " + String(bankPath))
+    GODOT_LOG_VERBOSE("FMOD Sound System: LOADING BANK " + String(bankPath))
     loading_banks.push_back(ref);
     if (flag != FMOD_STUDIO_LOAD_BANK_NONBLOCKING) { force_loading(); }
     return ref;
@@ -81,7 +81,7 @@ Ref<FmodFile> FmodCache::add_file(const String& filePath, unsigned int flag) {
     if (sound) {
         Ref<FmodFile> ref = FmodFile::create_ref(sound);
         files[filePath] = ref;
-        GODOT_LOG_INFO("FMOD Sound System: LOADING AS SOUND FILE" + String(filePath))
+        GODOT_LOG_VERBOSE("FMOD Sound System: LOADING AS SOUND FILE" + String(filePath))
         return ref;
     }
     return {};

--- a/src/fmod_server.cpp
+++ b/src/fmod_server.cpp
@@ -174,7 +174,7 @@ void FmodServer::init(const Ref<FmodGeneralSettings>& p_settings) {
     if (ERROR_CHECK(
           coreSystem->setFileSystem(&Callbacks::godotFileOpen, &Callbacks::godotFileClose, nullptr, nullptr, &Callbacks::godotSyncRead, &Callbacks::godotSyncCancel, -1)
         )) {
-        GODOT_LOG_INFO("Custom File System enabled.")
+        GODOT_LOG_VERBOSE("Custom File System enabled.")
     }
     cache = new FmodCache(system);
 }
@@ -763,7 +763,7 @@ void FmodServer::set_system_dsp_buffer_size(const Ref<FmodDspSettings>& p_settin
     int num_buffers = p_settings->get_dsp_buffer_count();
 
     if (buffer_length > 0 && num_buffers > 0 && ERROR_CHECK(coreSystem->setDSPBufferSize(buffer_length, num_buffers))) {
-        GODOT_LOG_INFO("FMOD Sound System: Successfully set DSP buffer size")
+        GODOT_LOG_VERBOSE("FMOD Sound System: Successfully set DSP buffer size")
     } else {
         GODOT_LOG_ERROR(vformat("FMOD Sound System: Failed to set DSP buffer size: %s, with buffer count: %s", buffer_length, num_buffers))
     }
@@ -842,7 +842,7 @@ void FmodServer::unload_file(const String& path) {
         return;
     }
     cache->remove_file(path);
-    GODOT_LOG_INFO("FMOD Sound System: UNLOADING FILE" + String(path))
+    GODOT_LOG_VERBOSE("FMOD Sound System: UNLOADING FILE" + String(path))
 }
 
 Ref<FmodSound> FmodServer::create_sound_instance(const String& path) {
@@ -867,7 +867,7 @@ void FmodServer::set_sound_3d_settings(const Ref<FmodSound3DSettings>& p_setting
         GODOT_LOG_ERROR("FMOD Sound System: Failed to set 3D settings - invalid distance factor!")
     } else if (ERROR_CHECK(coreSystem->set3DSettings(p_settings->get_doppler_scale(), distance_factor, p_settings->get_rolloff_scale()))) {
         distanceScale = distance_factor;
-        GODOT_LOG_INFO("FMOD Sound System: Successfully set global 3D settings")
+        GODOT_LOG_VERBOSE("FMOD Sound System: Successfully set global 3D settings")
     } else {
         GODOT_LOG_ERROR("FMOD Sound System: Failed to set 3D settings")
     }

--- a/src/helpers/common.h
+++ b/src/helpers/common.h
@@ -22,6 +22,7 @@
 #define MAX_EVENT_INSTANCE_COUNT 128
 
 #define GODOT_LOG_INFO(message) UtilityFunctions::print(message);
+#define GODOT_LOG_VERBOSE(message) UtilityFunctions::print_verbose(message);
 #define GODOT_LOG_WARNING(message) UtilityFunctions::push_warning(message, BOOST_CURRENT_FUNCTION, __FILE__, __LINE__);
 #define GODOT_LOG_ERROR(message) UtilityFunctions::push_error(message, BOOST_CURRENT_FUNCTION, __FILE__, __LINE__);
 

--- a/src/tools/fmod_editor_export_plugin.cpp
+++ b/src/tools/fmod_editor_export_plugin.cpp
@@ -20,7 +20,7 @@ void FmodEditorExportPlugin::_export_begin(const PackedStringArray& features, bo
         PackedStringArray files;
         list_files_in_folder(files, "res://", extension, excluded_folders);
         for (const String& file : files) {
-            GODOT_LOG_INFO(vformat("Adding %s to pck", file));
+            GODOT_LOG_VERBOSE(vformat("Adding %s to pck", file));
             add_file(file, FileAccess::get_file_as_bytes(file), false);
         }
     }


### PR DESCRIPTION
Simple change to make the plugin quieter when Godot is not in verbose mode. In that case, it should only print the initialization of the system. Logs for loading files and banks are now verbose.