### PR TITLE
Remove listener update when in editor

### DIFF
--- a/src/fmod_server.cpp
+++ b/src/fmod_server.cpp
@@ -1,3 +1,4 @@
+#include "classes/engine.hpp"
 #include "core/fmod_sound.h"
 #include "data/performance_data.h"
 #include "helpers/common.h"
@@ -227,8 +228,16 @@ void FmodServer::update() {
         if (!event->is_valid()) { runningEvents.erase(event); }
     }
 
-    _set_listener_attributes();
-    _update_performance_data();
+#ifdef TOOLS_ENABLED
+    if (!Engine::get_singleton()->is_editor_hint()) {
+#endif
+        // Editor only needs to run the server for events preview in the explorer.
+        //  We don't need to update performance_data and listeners
+        _set_listener_attributes();
+        _update_performance_data();
+#ifdef TOOLS_ENABLED
+    }
+#endif
 
     ERROR_CHECK(system->update());
 }


### PR DESCRIPTION
The last explorer update changed the FmodManager.gd into a tool script, allowing FmodServer to be updated and play event previews.
It had the side effects of adding a warning message, when starting the editor, complaining that no listener is set. 
I simply added a condition that will prevent listener (and performance data as well, because we only want them from a remote instance) to be updated by the FmodServer.