### PR TITLE
Increment version in plugin config

### DIFF
--- a/demo/addons/fmod/plugin.cfg
+++ b/demo/addons/fmod/plugin.cfg
@@ -1,7 +1,7 @@
 [plugin]
 
 name="FMOD GDExtension"
-description="FMOD GDExtension for Godot Engine 4.0"
+description="FMOD GDExtension for Godot Engine 4"
 author="Utopia-rise, Tristan Grespinet, Pierre-Thomas Meisels"
-version="4.0.0"
+version="4.2.0"
 script="FmodPlugin.gd"


### PR DESCRIPTION
I just downloaded the plugin and wondered why the version differed from the one I saw on the releases page. Also it works for Godot 4.2 as well, so it shouldn't only state Godot 4.0.