### PR TITLE
chore: update to godot 4.2.2

### DIFF
--- a/.github/actions/create-android-plugin/action.yaml
+++ b/.github/actions/create-android-plugin/action.yaml
@@ -1,7 +1,7 @@
 name: Create Fmod native build
 description: Creates fmod native build for a specific platform
 env:
-  GODOT_VERSION: 4.2
+  GODOT_VERSION: 4.2.2
 runs:
   using: composite
   steps:

--- a/.github/actions/create-native-build/action.yaml
+++ b/.github/actions/create-native-build/action.yaml
@@ -3,7 +3,7 @@ description: Creates fmod native build for a specific platform
 env:
   TARGET_PATH: demo/addons/fmod/libs/
   TARGET_NAME: libGodotFmod
-  GODOT_VERSION: 4.2
+  GODOT_VERSION: 4.2.2
   FMOD_VERSION: 20212
 inputs:
   platform:

--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -8,7 +8,7 @@ env:
   PROJECT_FOLDER: fmod-gdextension
   TARGET_PATH: demo/addons/fmod/libs/
   TARGET_NAME: libGodotFmod
-  GODOT_VERSION: 4.2
+  GODOT_VERSION: 4.2.2
   FMOD_VERSION: 20212
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ env:
   PROJECT_FOLDER: fmod-gdextension
   TARGET_PATH: demo/addons/fmod/libs/
   TARGET_NAME: libGodotFmod
-  GODOT_VERSION: 4.2
+  GODOT_VERSION: 4.2.2
   FMOD_VERSION: 20212
 
 jobs:

--- a/android-plugin/library/build.gradle.kts
+++ b/android-plugin/library/build.gradle.kts
@@ -63,5 +63,5 @@ tasks.build {
 dependencies {
     implementation("androidx.core:core-ktx:1.10.1")
     implementation(files("libraries/fmod.jar"))
-    compileOnly(files("libraries/godot-lib.4.2.stable.template_release.aar"))
+    compileOnly(files("libraries/godot-lib.4.2.2.stable.template_release.aar"))
 }


### PR DESCRIPTION
This updates plugin to godot `4.2.2`.