### PR TITLE
Removing FmodEditorExportPluginProxy class

### DIFF
--- a/demo/.godot/global_script_class_cache.cfg
+++ b/demo/.godot/global_script_class_cache.cfg
@@ -29,12 +29,6 @@ list=Array[Dictionary]([{
 "language": &"GDScript",
 "path": "res://addons/fmod/tool/property_editors/FmodBankPathEditorProperty.gd"
 }, {
-"base": &"FmodEditorExportPlugin",
-"class": &"FmodEditorExportPluginProxy",
-"icon": "",
-"language": &"GDScript",
-"path": "res://addons/fmod/FmodEditorExportPluginProxy.gd"
-}, {
 "base": &"EditorInspectorPlugin",
 "class": &"FmodEmitterPropertyInspectorPlugin",
 "icon": "",

--- a/demo/addons/fmod/FmodEditorExportPluginProxy.gd
+++ b/demo/addons/fmod/FmodEditorExportPluginProxy.gd
@@ -1,5 +1,0 @@
-# Here because gdextension does not support editor export plugin for now.
-# https://github.com/godotengine/godot/issues/80593
-@tool
-class_name FmodEditorExportPluginProxy
-extends FmodEditorExportPlugin

--- a/demo/addons/fmod/FmodPlugin.gd
+++ b/demo/addons/fmod/FmodPlugin.gd
@@ -11,7 +11,7 @@ const ADDON_PATH = "res://addons/fmod"
 var fmod_bank_explorer_window: PackedScene = load("res://addons/fmod/tool/ui/FmodBankExplorer.tscn")
 var bank_explorer: FmodBankExplorer
 var fmod_button: Button
-var export_plugin = FmodEditorExportPluginProxy.new()
+var export_plugin = FmodEditorExportPlugin.new()
 var emitter_inspector_plugin = FmodEmitterPropertyInspectorPlugin.new(self)
 var bank_loader_inspector_plugin = FmodBankLoaderPropertyInspectorPlugin.new(self)
 


### PR DESCRIPTION
FmodEditorExportPluginProxy was a workaround for a bug that existed in a previous version of Godot. That bug is now fixed, so there is no further need to have this class that inherits from the base FmodEditorExportPlugin.

This change simply deletes the file containing the inherited Proxy object, and replaces it's initial instantiation in FmodPlugin.gd with the base class.

I also removed it from the global_script_class_cash.cfg; I don't know if Godot checks items in the global script class cache to see if they still exist, but if not, this should cover it. 


Picture below illustrates recognition of FmodEditorExportPlugin when assigned as export_plugin, where before it would be colored like the definition of dummy_plugin, which is unrecognized due to a purposeful typo to show the difference.
![image](https://github.com/user-attachments/assets/3a156796-3fab-4ed1-8404-91955c16831c)
Tested a default scene with nothing going on in it other than a Node3D with an Emitter and Listener child, and no errors occur.