### PR TITLE
fix: avoid crash when event is not found by guid or path

### DIFF
--- a/demo/addons/fmod/tool/property_editors/FmodEventEditorProperty.gd
+++ b/demo/addons/fmod/tool/property_editors/FmodEventEditorProperty.gd
@@ -11,6 +11,10 @@ func _update_property():
 		return
 	_update_parameters()
 	var event_description: FmodEventDescription = FmodServer.get_event_from_guid(get_edited_object().event_guid)
+	
+	if event_description == null:
+		event_description = FmodServer.get_event(get_edited_object().event_name)
+	
 	former_event_description = event_description
 
 func _set_path_and_guid(path: String, guid: String):
@@ -22,6 +26,9 @@ func _set_path_and_guid(path: String, guid: String):
 
 func _update_parameters():
 	var event_description: FmodEventDescription = FmodServer.get_event_from_guid(get_edited_object().event_guid)
+	
+	if event_description == null:
+		return
 	
 	if former_event_description != null and event_description != former_event_description:
 		get_edited_object().tool_remove_all_parameters()

--- a/src/fmod_cache.cpp
+++ b/src/fmod_cache.cpp
@@ -144,11 +144,31 @@ Ref<FmodBus> FmodCache::get_bus(const String& busPath) {
 }
 
 Ref<FmodEventDescription> FmodCache::get_event(const FMOD_GUID& guid) {
-    return event_descriptions.get(guid);
+    if (
+      HashMap<FMOD_GUID, Ref<FmodEventDescription>, FmodGuidHashMapHasher, FmodGuidHashMapComparer>::Iterator iterator {
+          event_descriptions.find(guid)
+      }
+    ) {
+        return iterator->value;
+    }
+
+#ifdef DEBUG_ENABLED
+    GODOT_LOG_WARNING(vformat("Cannot find event with guid: %s", fmod_guid_to_string(guid)));
+#endif
+
+    return {};
 }
 
 Ref<FmodEventDescription> FmodCache::get_event(const String& eventPath) {
-    return event_descriptions.get(strings_to_guid.get(eventPath));
+    if (HashMap<String, FMOD_GUID>::Iterator iterator {strings_to_guid.find(eventPath)}) {
+        return get_event(iterator->value);
+    }
+
+#ifdef DEBUG_ENABLED
+    GODOT_LOG_WARNING(vformat("Cannot find event with path: %s", eventPath));
+#endif
+
+    return {};
 }
 
 bool FmodCache::is_master_loaded() {

--- a/src/nodes/fmod_event_emitter.h
+++ b/src/nodes/fmod_event_emitter.h
@@ -129,6 +129,12 @@ namespace godot {
 
         if (_autoplay) {
             load_event();
+
+            if (_event.is_null()) {
+                // No event loaded, nothing to do here
+                return;
+            }
+
             _event->set_volume(_volume);
             apply_parameters();
             set_space_attribute();
@@ -158,6 +164,12 @@ namespace godot {
                 return;
             } else if (_autoplay) {
                 load_event();
+
+                if (_event.is_null()) {
+                    // No event loaded, nothing to do here
+                    return;
+                }
+
                 _event->set_volume(_volume);
                 apply_parameters();
             }
@@ -221,6 +233,11 @@ namespace godot {
     template<class Derived, class NodeType>
     void FmodEventEmitter<Derived, NodeType>::play() {
         if (_event.is_null() || !_event->is_valid()) { load_event(); }
+
+        if (_event.is_null()) {
+            // No event loaded, nothing to do here
+            return;
+        }
 
         if (_attached) { set_space_attribute(); }
         if (!_programmer_callback_sound_key.is_empty()) {
@@ -331,6 +348,11 @@ namespace godot {
     template<class Derived, class NodeType>
     void FmodEventEmitter<Derived, NodeType>::preload_event() {
         Ref<FmodEventDescription> desc = _load_event_description();
+
+        if (desc.is_null()) {
+            return;
+        }
+
         desc->load_sample_data();
         _is_one_shot = desc->is_one_shot();
     }
@@ -338,6 +360,11 @@ namespace godot {
     template<class Derived, class NodeType>
     void FmodEventEmitter<Derived, NodeType>::load_event() {
         Ref<FmodEventDescription> desc = _load_event_description();
+
+        if (desc.is_null()) {
+            return;
+        }
+
         _event = FmodServer::get_singleton()->create_event_instance_from_description(desc);
         _event->set_callback(Callable(this, "_emit_callbacks"), FMOD_STUDIO_EVENT_CALLBACK_ALL);
         _is_one_shot = desc->is_one_shot();


### PR DESCRIPTION
This resolves #244 