### PR TITLE
Update to Godot 4.3

### DIFF
--- a/.github/actions/create-android-plugin/action.yaml
+++ b/.github/actions/create-android-plugin/action.yaml
@@ -1,7 +1,7 @@
 name: Create Fmod native build
 description: Creates fmod native build for a specific platform
 env:
-  GODOT_VERSION: 4.2.2
+  GODOT_VERSION: 4.3
 runs:
   using: composite
   steps:

--- a/.github/actions/create-native-build/action.yaml
+++ b/.github/actions/create-native-build/action.yaml
@@ -3,7 +3,7 @@ description: Creates fmod native build for a specific platform
 env:
   TARGET_PATH: demo/addons/fmod/libs/
   TARGET_NAME: libGodotFmod
-  GODOT_VERSION: 4.2.2
+  GODOT_VERSION: 4.3
   FMOD_VERSION: 20212
 inputs:
   platform:
@@ -32,9 +32,9 @@ runs:
       uses: actions/setup-python@v4
       with:
         # Semantic version range syntax or exact version of a Python version
-        python-version: '3.x'
+        python-version: "3.x"
         # Optional - x64 or x86 architecture, defaults to x64
-        architecture: 'x64'
+        architecture: "x64"
 
     # Setup scons, print python version and scons version info, so if anything is broken it won't run the build.
     #TODO: remove hardcoded scons version when https://github.com/godotengine/godot-cpp/pull/1526 is released

--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -8,7 +8,7 @@ env:
   PROJECT_FOLDER: fmod-gdextension
   TARGET_PATH: demo/addons/fmod/libs/
   TARGET_NAME: libGodotFmod
-  GODOT_VERSION: 4.2.2
+  GODOT_VERSION: 4.3
   FMOD_VERSION: 20212
 
 jobs:
@@ -192,7 +192,7 @@ jobs:
           ./run_tests.sh ../${{ matrix.godot-executable }}
 
   create-android-plugin:
-    needs: [ build ]
+    needs: [build]
     strategy:
       matrix:
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ env:
   PROJECT_FOLDER: fmod-gdextension
   TARGET_PATH: demo/addons/fmod/libs/
   TARGET_NAME: libGodotFmod
-  GODOT_VERSION: 4.2.2
+  GODOT_VERSION: 4.3
   FMOD_VERSION: 20212
 
 jobs:
@@ -178,7 +178,7 @@ jobs:
           shell: ${{ matrix.shell }}
 
   package-godot-addon:
-    needs: [ build ]
+    needs: [build]
     strategy:
       matrix:
         include:

--- a/android-plugin/library/build.gradle.kts
+++ b/android-plugin/library/build.gradle.kts
@@ -63,5 +63,5 @@ tasks.build {
 dependencies {
     implementation("androidx.core:core-ktx:1.10.1")
     implementation(files("libraries/fmod.jar"))
-    compileOnly(files("libraries/godot-lib.4.2.2.stable.template_release.aar"))
+    compileOnly(files("libraries/godot-lib.4.3.stable.template_release.aar"))
 }

--- a/demo/.godot/editor/project_metadata.cfg
+++ b/demo/.godot/editor/project_metadata.cfg
@@ -1,6 +1,6 @@
 [editor_metadata]
 
-executable_path="/Users/pierre-thomasmeisels/godot-4.2.2/Godot.app/Contents/MacOS/Godot"
+executable_path="/Users/pierre-thomasmeisels/godot-4.3/Godot.app/Contents/MacOS/Godot"
 use_advanced_connections=false
 
 [debug_options]

--- a/demo/project.godot
+++ b/demo/project.godot
@@ -34,7 +34,7 @@ modules="org/godotengine/godot/FmodSingleton"
 
 config/name="Fmod Demo"
 run/main_scene="res://low_level_2D/FmodScriptTest.tscn"
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.3")
 config/icon="res://icon.png"
 
 [autoload]

--- a/src/helpers/common.h
+++ b/src/helpers/common.h
@@ -116,7 +116,7 @@ namespace godot {
     }
 
     static bool is_dead(Object* node) {
-        if (!node || !UtilityFunctions::is_instance_valid(node)) {
+        if (!node || !UtilityFunctions::is_instance_id_valid(node->get_instance_id())) {
             return true;
         }
         return !Object::cast_to<Node>(node)->is_inside_tree();

--- a/src/nodes/fmod_event_emitter.h
+++ b/src/nodes/fmod_event_emitter.h
@@ -87,7 +87,7 @@ namespace godot {
         void tool_remove_parameter(uint64_t parameter_id);
 #endif
 
-        static StringName& get_class_static();
+        static const StringName& get_class_static();
 
     protected:
         void _emit_callbacks(const Dictionary& dict, const int type) const;
@@ -779,7 +779,7 @@ namespace godot {
 #endif
 
     template<class Derived, class NodeType>
-    StringName& FmodEventEmitter<Derived, NodeType>::get_class_static() {
+    const StringName& FmodEventEmitter<Derived, NodeType>::get_class_static() {
         return Derived::get_class_static();
     }
 

--- a/src/nodes/fmod_listener.h
+++ b/src/nodes/fmod_listener.h
@@ -24,7 +24,7 @@ namespace godot {
         void set_listener_weight(const float p_weight);
         float get_listener_weight() const;
 
-        static StringName& get_class_static();
+        static const StringName& get_class_static();
 
         FmodListener();
         ~FmodListener() = default;
@@ -185,7 +185,7 @@ namespace godot {
     }
 
     template<class Derived, class NodeType>
-    StringName& FmodListener<Derived, NodeType>::get_class_static() {
+    const StringName& FmodListener<Derived, NodeType>::get_class_static() {
         return Derived::get_class_static();
     }
 }// namespace godot


### PR DESCRIPTION
- updates `godot-cpp` to `godot-4.3-stable` branch
- various fixes to make this codebase compatible with new changes