### PR TITLE
fix: Check object before removing listener

### DIFF
--- a/demo/test/unit/test_bank.gd
+++ b/demo/test/unit/test_bank.gd
@@ -27,8 +27,7 @@ class TestBank:
 		FmodServer.add_listener(0, sprite)
 	
 	func after_all():
-		FmodServer.remove_listener(0)
-		assert_true(vehicleBank.get_loading_state() == 0 or vehicleBank.get_loading_state() == 1, "Loading state should be -1")
+		FmodServer.remove_listener(0, sprite)
 	
 	func test_assert_bank_bus_count():
 		var desiredValue: int = 0

--- a/demo/test/unit/test_bus.gd
+++ b/demo/test/unit/test_bus.gd
@@ -33,7 +33,7 @@ class TestBus:
 	
 	func after_all():
 		fmodEvent.release()
-		FmodServer.remove_listener(0)
+		FmodServer.remove_listener(0, sprite)
 	
 	func test_assert_should_has_master_bus():
 		var wanted: String = "bus:/"

--- a/demo/test/unit/test_callbacks.gd
+++ b/demo/test/unit/test_callbacks.gd
@@ -27,7 +27,7 @@ func before_all():
 	FmodServer.add_listener(0, sprite)
 
 func after_all():
-	FmodServer.remove_listener(0)
+	FmodServer.remove_listener(0, sprite)
 
 func test_assert_has_signals():
 	var emitter: FmodEventEmitter2D = FmodEventEmitter2D.new()

--- a/demo/test/unit/test_desc_event.gd
+++ b/demo/test/unit/test_desc_event.gd
@@ -33,7 +33,7 @@ class TestEventDescription:
 	
 	func after_all():
 		fmodEvent.release()
-		FmodServer.remove_listener(0)
+		FmodServer.remove_listener(0, sprite)
 	
 	func test_assert_should_create_and_release():
 		var desired_value: int = 2

--- a/demo/test/unit/test_event.gd
+++ b/demo/test/unit/test_event.gd
@@ -36,7 +36,7 @@ class TestEvent:
 	func after_all():
 		fmodEvent.stop(FmodServer.FMOD_STUDIO_STOP_IMMEDIATE)
 		fmodEvent.release()
-		FmodServer.remove_listener(0)
+		FmodServer.remove_listener(0, sprite)
 	
 	func test_should_has_event():
 		var wanted: String = "event:/Vehicles/Car Engine"

--- a/demo/test/unit/test_global.gd
+++ b/demo/test/unit/test_global.gd
@@ -30,7 +30,7 @@ class TestGlobal:
 		FmodServer.add_listener(0, sprite)
 	
 	func after_all():
-		FmodServer.remove_listener(0)
+		FmodServer.remove_listener(0, sprite)
 	
 	func test_assert_should_have_performance_data():
 		var perf_data: FmodPerformanceData = FmodServer.get_performance_data()

--- a/demo/test/unit/test_listener.gd
+++ b/demo/test/unit/test_listener.gd
@@ -30,7 +30,7 @@ class TestListener:
 		FmodServer.add_listener(0, sprite)
 	
 	func after_all():
-		FmodServer.remove_listener(0)
+		FmodServer.remove_listener(0, sprite)
 	
 	func test_assert_should_set_listener_num():
 		var desiredValue: int = 1
@@ -55,7 +55,7 @@ class TestListener:
 		FmodServer.add_listener(1, sprite)
 		FmodServer.set_listener_weight(1, desiredValue)
 		assert_listener_weight(1, desiredValue)
-		FmodServer.remove_listener(1)
+		FmodServer.remove_listener(1, sprite)
 		FmodServer.set_listener_number(1)
 	
 	func test_assert_attach_object_to_listener():
@@ -67,9 +67,29 @@ class TestListener:
 		assert_no_object_attached_to_listener(desired_listener)
 		FmodServer.add_listener(desired_listener, sprite)
 		assert_true(FmodServer.get_object_attached_to_listener(desired_listener) == node_instance, "Both listeners should be attached to same object")
-		FmodServer.remove_listener(1)
+		FmodServer.remove_listener(1, sprite)
 		assert_no_object_attached_to_listener(desired_listener)
 		FmodServer.set_listener_number(1)
+	
+	func test_attach_two_object_to_listeners():
+		var desired_listener := 1
+		FmodServer.set_listener_number(2);
+		FmodServer.add_listener(desired_listener, sprite)
+		
+		assert_eq(FmodServer.get_object_attached_to_listener(desired_listener), sprite)
+		
+		var node := Node2D.new()
+		
+		FmodServer.add_listener(desired_listener, node)
+		assert_eq(FmodServer.get_object_attached_to_listener(desired_listener), node)
+		FmodServer.remove_listener(desired_listener, sprite)
+		assert_eq(FmodServer.get_object_attached_to_listener(desired_listener), node)
+		FmodServer.remove_listener(desired_listener, node)
+		assert_no_object_attached_to_listener(desired_listener)
+		
+		node.free()
+		
+		FmodServer.set_listener_number(1);
 	
 	func assert_listener_num(desiredValue: int):
 		assert_eq(FmodServer.get_listener_number(), desiredValue, "There should be " + str(desiredValue) + " listeners.")

--- a/demo/test/unit/test_vca.gd
+++ b/demo/test/unit/test_vca.gd
@@ -30,7 +30,7 @@ class TestVCA:
 		FmodServer.add_listener(0, sprite)
 	
 	func after_all():
-		FmodServer.remove_listener(0)
+		FmodServer.remove_listener(0, sprite)
 	
 	func test_assert_valid_paths():
 		assert_true(FmodServer.check_vca_path("vca:/Environment"), "vca:/Environment should be present")

--- a/src/fmod_server.cpp
+++ b/src/fmod_server.cpp
@@ -63,8 +63,8 @@ void FmodServer::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_global_parameter_desc_list"), &FmodServer::get_global_parameter_desc_list);
 
     // LISTENERS
-    ClassDB::bind_method(D_METHOD("add_listener", "index", "gameObj"), &FmodServer::add_listener);
-    ClassDB::bind_method(D_METHOD("remove_listener", "index"), &FmodServer::remove_listener);
+    ClassDB::bind_method(D_METHOD("add_listener", "index", "game_obj"), &FmodServer::add_listener);
+    ClassDB::bind_method(D_METHOD("remove_listener", "index", "game_obj"), &FmodServer::remove_listener);
     ClassDB::bind_method(D_METHOD("set_listener_number", "listenerNumber"), &FmodServer::set_system_listener_number);
     ClassDB::bind_method(D_METHOD("get_listener_number"), &FmodServer::get_system_listener_number);
     ClassDB::bind_method(D_METHOD("get_listener_weight", "index"), &FmodServer::get_system_listener_weight);
@@ -308,11 +308,11 @@ void FmodServer::set_system_listener_number(int p_listenerNumber) {
     }
 }
 
-void FmodServer::add_listener(int index, Object* gameObj) {
-    if (!is_fmod_valid(gameObj)) { return; }
+void FmodServer::add_listener(int index, Object* game_obj) {
+    if (!is_fmod_valid(game_obj)) { return; }
     if (index >= 0 && index < systemListenerNumber) {
         Listener* listener = &listeners[index];
-        listener->gameObj = gameObj;
+        listener->gameObj = game_obj;
         ERROR_CHECK(system->setListenerWeight(index, listener->weight));
         int count = 0;
         for (int i = 0; i < systemListenerNumber; ++i) {
@@ -325,9 +325,14 @@ void FmodServer::add_listener(int index, Object* gameObj) {
     }
 }
 
-void FmodServer::remove_listener(int index) {
+void FmodServer::remove_listener(int index, Object* game_obj) {
     if (index >= 0 && index < systemListenerNumber) {
         Listener* listener = &listeners[index];
+
+        if (listener->gameObj != game_obj) {
+            return;
+        }
+
         listener->gameObj = nullptr;
         ERROR_CHECK(system->setListenerWeight(index, 0));
         int count = 0;

--- a/src/fmod_server.h
+++ b/src/fmod_server.h
@@ -177,8 +177,8 @@ namespace godot {
         Array get_global_parameter_desc_list();
 
         // LISTENERS
-        void add_listener(int index, Object* gameObj);
-        void remove_listener(int index);
+        void add_listener(int index, Object* game_obj);
+        void remove_listener(int index, Object* game_obj);
         void set_system_listener_number(int listenerNumber);
         int get_system_listener_number() const;
         float get_system_listener_weight(int index);

--- a/src/nodes/fmod_listener.h
+++ b/src/nodes/fmod_listener.h
@@ -78,7 +78,7 @@ namespace godot {
         if (Engine::get_singleton()->is_editor_hint()) { return; }
 #endif
 
-        FmodServer::get_singleton()->remove_listener(_listener_index);
+        FmodServer::get_singleton()->remove_listener(_listener_index, this);
         _is_added = false;
     }
 


### PR DESCRIPTION
This resolves #252 by addign `Object*` parameter to `FmodServer::remove_listener` to check if same object before removing listener.