### PR TITLE
enh: Simplify emitter event playing

### DIFF
--- a/demo/high_level_2D/SayWelcomeButton.gd
+++ b/demo/high_level_2D/SayWelcomeButton.gd
@@ -12,5 +12,6 @@ func _on_pressed():
 	var event_emitter = FmodEventEmitter2D.new()
 	event_emitter.event_guid = "{9aa2ecc5-ea4b-4ebe-85c3-054b11b21dcd}"
 	event_emitter.autoplay = true
+	event_emitter.auto_release = true
 	event_emitter.set_programmer_callback("welcome")
 	welcome_option_button.current_bank_loader.add_child(event_emitter)

--- a/src/fmod_cache.cpp
+++ b/src/fmod_cache.cpp
@@ -171,6 +171,26 @@ Ref<FmodEventDescription> FmodCache::get_event(const String& eventPath) {
     return {};
 }
 
+FMOD_GUID FmodCache::get_event_guid(const String& event_path) {
+    if (HashMap<String, FMOD_GUID>::Iterator iterator {strings_to_guid.find(event_path)}) {
+        return iterator->value;
+    }
+
+    return {};
+}
+
+String FmodCache::get_event_path(const FMOD_GUID& guid) {
+    if (
+            HashMap<FMOD_GUID, Ref<FmodEventDescription>, FmodGuidHashMapHasher, FmodGuidHashMapComparer>::Iterator iterator{
+                    event_descriptions.find(guid)
+            }
+            ) {
+        return iterator->value->get_path();
+    }
+
+    return {};
+}
+
 bool FmodCache::is_master_loaded() {
     return banks.size() > 0;
 }

--- a/src/fmod_cache.h
+++ b/src/fmod_cache.h
@@ -82,6 +82,8 @@ namespace godot {
         Ref<FmodBus> get_bus(const String& busPath);
         Ref<FmodEventDescription> get_event(const FMOD_GUID& guid);
         Ref<FmodEventDescription> get_event(const String& eventPath);
+        FMOD_GUID get_event_guid(const String& event_path);
+        String get_event_path(const FMOD_GUID& guid);
     };
 }// namespace godot
 

--- a/src/fmod_server.cpp
+++ b/src/fmod_server.cpp
@@ -39,6 +39,8 @@ void FmodServer::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_bus", "busPath"), &FmodServer::get_bus);
     ClassDB::bind_method(D_METHOD("get_event_from_guid", "guid"), &FmodServer::get_event_from_guid);
     ClassDB::bind_method(D_METHOD("get_event", "eventPath"), &FmodServer::get_event);
+    ClassDB::bind_method(D_METHOD("get_event_guid", "event_path"), &FmodServer::get_event_guid);
+    ClassDB::bind_method(D_METHOD("get_event_path", "guid"), &FmodServer::get_event_path);
     ClassDB::bind_method(D_METHOD("get_all_vca"), &FmodServer::get_all_vca);
     ClassDB::bind_method(D_METHOD("get_all_buses"), &FmodServer::get_all_buses);
     ClassDB::bind_method(D_METHOD("get_all_event_descriptions"), &FmodServer::get_all_event_descriptions);
@@ -559,6 +561,22 @@ Ref<FmodEventDescription> FmodServer::get_event_from_guid_internal(const FMOD_GU
 
 Ref<FmodEventDescription> FmodServer::get_event(const String& eventPath) {
     return cache->get_event(eventPath);
+}
+
+FMOD_GUID FmodServer::get_event_guid_internal(const String& event_path) {
+    return cache->get_event_guid(event_path);
+}
+
+String FmodServer::get_event_guid(const String& event_path) {
+    return fmod_guid_to_string(get_event_guid_internal(event_path));
+}
+
+String FmodServer::get_event_path_internal(const FMOD_GUID& guid) {
+    return cache->get_event_path(guid);
+}
+
+String FmodServer::get_event_path(const String& guid) {
+    return cache->get_event_path(string_to_fmod_guid(guid.utf8().get_data()));
 }
 
 Array FmodServer::get_all_vca() {

--- a/src/fmod_server.h
+++ b/src/fmod_server.h
@@ -153,6 +153,10 @@ namespace godot {
         Ref<FmodEventDescription> get_event_from_guid(const String& guid);
         Ref<FmodEventDescription> get_event_from_guid_internal(const FMOD_GUID& guid);
         Ref<FmodEventDescription> get_event(const String& eventPath);
+        FMOD_GUID get_event_guid_internal(const String& event_path);
+        String get_event_guid(const String& event_path);
+        String get_event_path_internal(const FMOD_GUID& guid);
+        String get_event_path(const String& guid);
         Array get_all_vca();
         Array get_all_buses();
         Array get_all_event_descriptions();

--- a/src/studio/fmod_event.cpp
+++ b/src/studio/fmod_event.cpp
@@ -91,7 +91,6 @@ void FmodEvent::set_parameter_by_id_with_label(uint64_t parameter_id, const Stri
 }
 
 void FmodEvent::release() const {
-    _wrapped->setUserData(nullptr);
     ERROR_CHECK(_wrapped->release());
 }
 
@@ -241,4 +240,10 @@ const String& FmodEvent::get_programmers_callback_sound_key() const {
 
 void FmodEvent::set_distance_scale(float scale){
     distanceScale = scale;
+}
+
+FmodEvent::~FmodEvent() {
+    if (is_valid()) {
+        _wrapped->setUserData(nullptr);
+    }
 }

--- a/src/studio/fmod_event.h
+++ b/src/studio/fmod_event.h
@@ -16,7 +16,7 @@ namespace godot {
 
     public:
         FmodEvent() = default;
-        ~FmodEvent() override = default;
+        ~FmodEvent() override;
 
         float get_parameter_by_name(const String& parameter_name) const;
         void set_parameter_by_name(const String& parameter_name, float value) const;

--- a/src/studio/fmod_event_description.cpp
+++ b/src/studio/fmod_event_description.cpp
@@ -159,7 +159,7 @@ Ref<FmodParameterDescription> FmodEventDescription::get_parameter_by_id(uint64_t
     return param_desc;
 }
 
-int FmodEventDescription::get_parameter_count() {
+int FmodEventDescription::get_parameter_count() const {
     int count = 0;
     ERROR_CHECK(_wrapped->getParameterDescriptionCount(&count));
     return count;
@@ -174,7 +174,7 @@ Ref<FmodParameterDescription> FmodEventDescription::get_parameter_by_index(int i
     return param_desc;
 }
 
-Array FmodEventDescription::get_parameters() {
+Array FmodEventDescription::get_parameters() const {
     Array parameters;
     for (int i = 0; i < get_parameter_count(); ++i) {
         parameters.append(get_parameter_by_index(i));

--- a/src/studio/fmod_event_description.h
+++ b/src/studio/fmod_event_description.h
@@ -30,9 +30,9 @@ namespace godot {
         float get_sound_size();
         Ref<FmodParameterDescription> get_parameter_by_name(const String& name) const;
         Ref<FmodParameterDescription> get_parameter_by_id(uint64_t id) const;
-        int get_parameter_count();
+        int get_parameter_count() const;
         Ref<FmodParameterDescription> get_parameter_by_index(int index) const;
-        Array get_parameters();
+        Array get_parameters() const;
         String get_parameter_label_by_id(uint64_t id, int label_index) const;
         String get_parameter_label_by_name(const String& parameter_name, int label_index) const;
         String get_parameter_label_by_index(int index, int label_index) const;


### PR DESCRIPTION
When event GUID is set, it will also set event_name, reverse is also true.
When event guid or name is set it stop current event and start the new one, it also clear parameters.
`auto_release` is now only for releasing node, not event. Event is automatically released.
If event has finished playing and emitter is autoplay, it will play again the event (enable play loop)