### PR TITLE
fix: Add ios xcframework build to CI

### DIFF
--- a/.github/actions/create-native-build/action.yaml
+++ b/.github/actions/create-native-build/action.yaml
@@ -10,8 +10,6 @@ inputs:
     description: The platform to build for.
   target:
     description: The target to build.
-  artifact-extension:
-    description: Extension of the compiled artifact
   additional-python-packages:
     description: Additional python package to install.
   flags:

--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -23,7 +23,6 @@ jobs:
             os: "windows-2022"
             platform: windows
             target: editor
-            artifact-extension: dll
             additional-python-packages: pywin32
             fmod-executable-suffix: win-installer.exe
             shell: pwsh
@@ -32,7 +31,6 @@ jobs:
             os: "windows-2022"
             platform: windows
             target: template_debug
-            artifact-extension: dll
             additional-python-packages: pywin32
             fmod-executable-suffix: win-installer.exe
             shell: pwsh
@@ -41,7 +39,6 @@ jobs:
             os: "windows-2022"
             platform: windows
             target: template_release
-            artifact-extension: dll
             additional-python-packages: pywin32
             fmod-executable-suffix: win-installer.exe
             shell: pwsh
@@ -50,7 +47,6 @@ jobs:
             os: "ubuntu-20.04"
             platform: linux
             target: editor
-            artifact-extension: so
             fmod-executable-suffix: linux.tar.gz
             fmod-core-platform-folder: linux/core/lib/x86_64
             fmod-studio-platform-folder: linux/studio/lib/x86_64
@@ -63,7 +59,6 @@ jobs:
             os: "ubuntu-20.04"
             platform: linux
             target: template_debug
-            artifact-extension: so
             fmod-executable-suffix: linux.tar.gz
             shell: bash
 
@@ -71,7 +66,6 @@ jobs:
             os: "ubuntu-20.04"
             platform: linux
             target: template_release
-            artifact-extension: so
             fmod-executable-suffix: linux.tar.gz
             shell: bash
 
@@ -79,7 +73,6 @@ jobs:
             os: "macos-13"
             platform: macos
             target: editor
-            artifact-extension: framework
             fmod-executable-suffix: osx.dmg
             fmod-core-platform-folder: osx/core/lib
             fmod-studio-platform-folder: osx/studio/lib
@@ -92,7 +85,6 @@ jobs:
             os: "macos-13"
             platform: macos
             target: template_debug
-            artifact-extension: framework
             fmod-executable-suffix: osx.dmg
             shell: bash
 
@@ -100,7 +92,6 @@ jobs:
             os: "macos-13"
             platform: macos
             target: template_release
-            artifact-extension: framework
             fmod-executable-suffix: osx.dmg
             shell: bash
 
@@ -108,7 +99,6 @@ jobs:
             os: "ubuntu-20.04"
             platform: android
             target: editor
-            artifact-extension: so
             fmod-executable-suffix: android.tar.gz
             flags: ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME arch=arm64
             shell: bash
@@ -117,7 +107,6 @@ jobs:
             os: "ubuntu-20.04"
             platform: android
             target: template_debug
-            artifact-extension: so
             fmod-executable-suffix: android.tar.gz
             flags: ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME arch=arm64
             shell: bash
@@ -126,7 +115,6 @@ jobs:
             os: "ubuntu-20.04"
             platform: android
             target: template_release
-            artifact-extension: so
             fmod-executable-suffix: android.tar.gz
             flags: ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME arch=arm64
             shell: bash
@@ -135,18 +123,14 @@ jobs:
             os: "macos-13"
             platform: ios
             target: template_debug
-            artifact-extension: dylib
             fmod-executable-suffix: ios.dmg
-            flags: arch=arm64
             shell: bash
 
           - name: iOS Release Compilation
             os: "macos-13"
             platform: ios
             target: template_release
-            artifact-extension: dylib
             fmod-executable-suffix: ios.dmg
-            flags: arch=arm64
             shell: bash
 
     steps:
@@ -168,7 +152,6 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
           target: ${{ matrix.target }}
-          artifact-extension: ${{ matrix.artifact-extension }}
           additional-python-packages: ${{ matrix.additional-python-packages }}
           flags: ${{ matrix.flags }}
           fmod-executable-suffix: ${{ matrix.fmod-executable-suffix }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
             os: "windows-2022"
             platform: windows
             target: editor
-            artifact-extension: dll
             additional-python-packages: pywin32
             fmod-executable-suffix: win-installer.exe
             shell: pwsh
@@ -33,7 +32,6 @@ jobs:
             os: "windows-2022"
             platform: windows
             target: template_debug
-            artifact-extension: dll
             additional-python-packages: pywin32
             fmod-executable-suffix: win-installer.exe
             shell: pwsh
@@ -42,7 +40,6 @@ jobs:
             os: "windows-2022"
             platform: windows
             target: template_release
-            artifact-extension: dll
             additional-python-packages: pywin32
             fmod-executable-suffix: win-installer.exe
             shell: pwsh
@@ -51,7 +48,6 @@ jobs:
             os: "ubuntu-20.04"
             platform: linux
             target: editor
-            artifact-extension: so
             fmod-executable-suffix: linux.tar.gz
             fmod-core-platform-folder: linux/core/lib/x86_64
             fmod-studio-platform-folder: linux/studio/lib/x86_64
@@ -64,7 +60,6 @@ jobs:
             os: "ubuntu-20.04"
             platform: linux
             target: template_debug
-            artifact-extension: so
             fmod-executable-suffix: linux.tar.gz
             shell: bash
 
@@ -72,7 +67,6 @@ jobs:
             os: "ubuntu-20.04"
             platform: linux
             target: template_release
-            artifact-extension: so
             fmod-executable-suffix: linux.tar.gz
             shell: bash
 
@@ -80,7 +74,6 @@ jobs:
             os: "macos-13"
             platform: macos
             target: editor
-            artifact-extension: framework
             fmod-executable-suffix: osx.dmg
             fmod-core-platform-folder: osx/core/lib
             fmod-studio-platform-folder: osx/studio/lib
@@ -93,7 +86,6 @@ jobs:
             os: "macos-13"
             platform: macos
             target: template_debug
-            artifact-extension: framework
             fmod-executable-suffix: osx.dmg
             shell: bash
 
@@ -101,7 +93,6 @@ jobs:
             os: "macos-13"
             platform: macos
             target: template_release
-            artifact-extension: framework
             fmod-executable-suffix: osx.dmg
             shell: bash
 
@@ -109,7 +100,6 @@ jobs:
             os: "ubuntu-20.04"
             platform: android
             target: editor
-            artifact-extension: so
             fmod-executable-suffix: android.tar.gz
             flags: ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME arch=arm64
             shell: bash
@@ -118,7 +108,6 @@ jobs:
             os: "ubuntu-20.04"
             platform: android
             target: template_debug
-            artifact-extension: so
             fmod-executable-suffix: android.tar.gz
             flags: ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME arch=arm64
             shell: bash
@@ -127,7 +116,6 @@ jobs:
             os: "ubuntu-20.04"
             platform: android
             target: template_release
-            artifact-extension: so
             fmod-executable-suffix: android.tar.gz
             flags: ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME arch=arm64
             shell: bash
@@ -136,18 +124,14 @@ jobs:
             os: "macos-13"
             platform: ios
             target: template_debug
-            artifact-extension: dylib
             fmod-executable-suffix: ios.dmg
-            flags: arch=arm64
             shell: bash
 
           - name: iOS Release Compilation
             os: "macos-13"
             platform: ios
             target: template_release
-            artifact-extension: dylib
             fmod-executable-suffix: ios.dmg
-            flags: arch=arm64
             shell: bash
 
     steps:
@@ -169,7 +153,6 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
           target: ${{ matrix.target }}
-          artifact-extension: ${{ matrix.artifact-extension }}
           additional-python-packages: ${{ matrix.additional-python-packages }}
           flags: ${{ matrix.flags }}
           fmod-executable-suffix: ${{ matrix.fmod-executable-suffix }}

--- a/demo/addons/fmod/.gitignore
+++ b/demo/addons/fmod/.gitignore
@@ -2,4 +2,5 @@
 *.a
 *.dylib
 *.so
+*.xcframework
 !libs/

--- a/demo/addons/fmod/fmod.gdextension
+++ b/demo/addons/fmod/fmod.gdextension
@@ -16,8 +16,8 @@ android.debug.x86_64 = "res://addons/fmod/libs/android/x86_64/libGodotFmod.andro
 android.release.x86_64 = "res://addons/fmod/libs/android/x86_64/libGodotFmod.android.template_release.x86_64.so"
 android.debug.arm64 = "res://addons/fmod/libs/android/arm64/libGodotFmod.android.template_debug.arm64.so"
 android.release.arm64 = "res://addons/fmod/libs/android/arm64/libGodotFmod.android.template_release.arm64.so"
-ios.debug  = "res://addons/fmod/libs/ios/libGodotFmod.ios.template_debug.universal.dylib"
-ios.release  = "res://addons/fmod/libs/ios/libGodotFmod.ios.template_release.universal.dylib"
+ios.debug  = "res://addons/fmod/libs/ios/libGodotFmod.ios.template_debug.universal.xcframework"
+ios.release  = "res://addons/fmod/libs/ios/libGodotFmod.ios.template_release.universal.xcframework"
 
 [icons]
 FmodEventEmitter2D = "res://addons/fmod/icons/fmod_icon.svg"


### PR DESCRIPTION
This adds ios xcframework build to CI according to https://github.com/godotengine/godot/issues/90168