### PR TITLE
fix: Remove performance monitor on exit to avoid crash

### DIFF
--- a/demo/addons/fmod/FmodManager.gd
+++ b/demo/addons/fmod/FmodManager.gd
@@ -1,9 +1,16 @@
 @tool
 extends Node
 
+var performance_display: PerformancesDisplay
+
 func _ready():
 	process_mode = PROCESS_MODE_ALWAYS
-	add_child(PerformancesDisplay.new())
+	performance_display = PerformancesDisplay.new()
+	add_child(performance_display)
+
+func _exit_tree() -> void:
+	remove_child(performance_display)
+	performance_display.free()
 
 func _process(delta):
 	FmodServer.update()

--- a/demo/addons/fmod/tool/performances/PerformancesDisplay.gd
+++ b/demo/addons/fmod/tool/performances/PerformancesDisplay.gd
@@ -35,6 +35,27 @@ func _enter_tree():
 	add_monitor(FILE_STREAM_CATEGORY, func(): return performance_data.stream_bytes_read)
 	add_monitor(FILE_OTHER_CATEGORY, func(): return performance_data.other_bytes_read)
 
+func _exit_tree() -> void:
+	remove_monitor(CORE_CPU_DSP_CATEGORY)
+	remove_monitor(CORE_CPU_GEOMETRY_CATEGORY)
+	remove_monitor(CORE_CPU_STREAM_CATEGORY)
+	remove_monitor(CORE_CPU_UPDATE_CATEGORY)
+	remove_monitor(CORE_CPU_CONVOLUTION_THREAD1_CATEGORY)
+	remove_monitor(CORE_CPU_CONVOLUTION_THREAD2_CATEGORY)
+	
+	remove_monitor(STUDIO_CPU_UPDATE_CATEGORY)
+	
+	remove_monitor(MEMORY_CURRENTLY_ALLOCATED_CATEGORY)
+	remove_monitor(MEMORY_MAX_ALLOCATED_CATEGORY)
+	
+	remove_monitor(FILE_SAMPLE_CATEGORY)
+	remove_monitor(FILE_STREAM_CATEGORY)
+	remove_monitor(FILE_OTHER_CATEGORY)
+
 func add_monitor(title: String, callable: Callable) -> void:
 	if not Performance.has_custom_monitor(title):
 		Performance.add_custom_monitor(title, callable)
+
+func remove_monitor(title: String) -> void:
+	if Performance.has_custom_monitor(title):
+		Performance.remove_custom_monitor(title)


### PR DESCRIPTION
This resolves #282 