### PR TITLE
fix: set FmodListener's index property usage to default

### DIFF
--- a/src/nodes/fmod_listener.h
+++ b/src/nodes/fmod_listener.h
@@ -156,7 +156,7 @@ namespace godot {
             "listener_index",
             PROPERTY_HINT_NONE,
             "",
-            PROPERTY_USAGE_EDITOR
+            PROPERTY_USAGE_DEFAULT
           ),
           "set_listener_index",
           "get_listener_index"


### PR DESCRIPTION
There was a mistake in listener's index property registration preventing it from being registered in scene: it was in editor usage.  

This resolves #291 