### PR TITLE
fix: return parameter value in emitter's get_parameter methods

### DIFF
--- a/src/nodes/fmod_event_emitter.h
+++ b/src/nodes/fmod_event_emitter.h
@@ -271,10 +271,10 @@ namespace godot {
     template<class Derived, class NodeType>
     Variant FmodEventEmitter<Derived, NodeType>::get_parameter(const String& p_name) const {
         if (Parameter* parameter {_find_parameter(p_name)}) {
-            return parameter;
+            return parameter->value;
         }
 
-        return nullptr;
+        return Variant();
     }
 
     template<class Derived, class NodeType>
@@ -297,10 +297,10 @@ namespace godot {
     template<class Derived, class NodeType>
     Variant FmodEventEmitter<Derived, NodeType>::get_parameter_by_id(uint64_t p_id) const {
         if (Parameter* parameter {_find_parameter(p_id)}) {
-            return parameter;
+            return parameter->value;
         }
 
-        return nullptr;
+        return Variant();
     }
 
     template<class Derived, class NodeType>


### PR DESCRIPTION
We were returning a pointer to a non godot type in `FmodEventEmitter::get_parameter` methods, which was converted to a bool.  
This returns the actual value of parameter.