### PR TITLE
enh: sets the FMOD random seed to system time before initialization (#273)

### DIFF
--- a/src/fmod_server.cpp
+++ b/src/fmod_server.cpp
@@ -162,6 +162,14 @@ void FmodServer::init(const Ref<FmodGeneralSettings>& p_settings) {
         ERROR_CHECK(system->getCoreSystem(&coreSystem));
     }
 
+    // editing advanced settings to set random seed before system initialization
+    FMOD_ADVANCEDSETTINGS advancedSettings = {};
+    advancedSettings.cbSize = sizeof(FMOD_ADVANCEDSETTINGS);
+    ERROR_CHECK(coreSystem->getAdvancedSettings(&advancedSettings));
+
+    advancedSettings.randomSeed = static_cast<unsigned int>(std::time(0));// Use time as a seed
+    ERROR_CHECK(coreSystem->setAdvancedSettings(&advancedSettings));
+
     FMOD_STUDIO_INITFLAGS studio_init_flags = FMOD_STUDIO_INIT_NORMAL;
 
     if (


### PR DESCRIPTION
Setting FMOD's Advanced Settings's random seed to system time. 