### PR TITLE
Remove fixed size arrays when loading vca's, busses and events

### DIFF
--- a/src/helpers/common.h
+++ b/src/helpers/common.h
@@ -16,9 +16,6 @@
 #define MAX_PATH_SIZE 512
 #define MAX_DRIVER_NAME_SIZE 256
 
-#define MAX_VCA_COUNT 64
-#define MAX_BUS_COUNT 64
-#define MAX_EVENT_DESCRIPTION_COUNT 256
 #define MAX_EVENT_INSTANCE_COUNT 128
 
 #define GODOT_LOG_INFO(message) UtilityFunctions::print(message);
@@ -112,74 +109,74 @@ public:                                                                  \
 private:
 
 namespace godot {
-    static bool is_dead(Object* node) {
-        if (!node || !UtilityFunctions::is_instance_id_valid(node->get_instance_id())) {
-            return true;
-        }
-        return !Object::cast_to<Node>(node)->is_inside_tree();
-    }
+	static bool is_dead(Object* node) {
+		if (!node || !UtilityFunctions::is_instance_id_valid(node->get_instance_id())) {
+			return true;
+		}
+		return !Object::cast_to<Node>(node)->is_inside_tree();
+	}
 
-    static bool is_fmod_valid(Object* node) {
-        if (node) {
-            bool ret = Node::cast_to<Node3D>(node) || Node::cast_to<CanvasItem>(node);
-            if (!ret) { GODOT_LOG_ERROR("Invalid Object. A listener has to be either a Node3D or CanvasItem.") }
-            return ret;
-        }
-        GODOT_LOG_ERROR("Object is null")
-        return false;
-    }
+	static bool is_fmod_valid(Object* node) {
+		if (node) {
+			bool ret = Node::cast_to<Node3D>(node) || Node::cast_to<CanvasItem>(node);
+			if (!ret) { GODOT_LOG_ERROR("Invalid Object. A listener has to be either a Node3D or CanvasItem.") }
+			return ret;
+		}
+		GODOT_LOG_ERROR("Object is null")
+			return false;
+	}
 
-    template<class T>
-    static inline Ref<T> create_ref() {
-        Ref<T> ref;
-        ref.instantiate();
-        return ref;
-    }
+	template<class T>
+	static inline Ref<T> create_ref() {
+		Ref<T> ref;
+		ref.instantiate();
+		return ref;
+	}
 
-    static inline FMOD_GUID string_to_fmod_guid(const char* guid) {
-        FMOD_GUID result;
-        sscanf(guid,
-               "{%8x-%4hx-%4hx-%2hhx%2hhx-%2hhx%2hhx%2hhx%2hhx%2hhx%2hhx}",
-               &result.Data1, &result.Data2, &result.Data3,
-               &result.Data4[0], &result.Data4[1], &result.Data4[2], &result.Data4[3],
-               &result.Data4[4], &result.Data4[5], &result.Data4[6], &result.Data4[7]);
-        return result;
-    }
+	static inline FMOD_GUID string_to_fmod_guid(const char* guid) {
+		FMOD_GUID result;
+		sscanf(guid,
+			"{%8x-%4hx-%4hx-%2hhx%2hhx-%2hhx%2hhx%2hhx%2hhx%2hhx%2hhx}",
+			&result.Data1, &result.Data2, &result.Data3,
+			&result.Data4[0], &result.Data4[1], &result.Data4[2], &result.Data4[3],
+			&result.Data4[4], &result.Data4[5], &result.Data4[6], &result.Data4[7]);
+		return result;
+	}
 
-    static inline String fmod_guid_to_string(const FMOD_GUID& guid) {
-        char result[39];
-        snprintf(result, sizeof(result), "{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
-                 guid.Data1, guid.Data2, guid.Data3,
-                 guid.Data4[0], guid.Data4[1], guid.Data4[2], guid.Data4[3],
-                 guid.Data4[4], guid.Data4[5], guid.Data4[6], guid.Data4[7]);
-        return result;
-    }
+	static inline String fmod_guid_to_string(const FMOD_GUID& guid) {
+		char result[39];
+		snprintf(result, sizeof(result), "{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
+			guid.Data1, guid.Data2, guid.Data3,
+			guid.Data4[0], guid.Data4[1], guid.Data4[2], guid.Data4[3],
+			guid.Data4[4], guid.Data4[5], guid.Data4[6], guid.Data4[7]);
+		return result;
+	}
 
-    static inline uint64_t fmod_parameter_id_to_ulong(const FMOD_STUDIO_PARAMETER_ID& parameter_id) {
-        const unsigned int first_id_part {parameter_id.data1};
-        return (static_cast<uint64_t>(first_id_part) << 32) | static_cast<uint64_t>(parameter_id.data2);
-    }
+	static inline uint64_t fmod_parameter_id_to_ulong(const FMOD_STUDIO_PARAMETER_ID& parameter_id) {
+		const unsigned int first_id_part{ parameter_id.data1 };
+		return (static_cast<uint64_t>(first_id_part) << 32) | static_cast<uint64_t>(parameter_id.data2);
+	}
 
-    static inline FMOD_STUDIO_PARAMETER_ID ulong_to_fmod_parameter_id(uint64_t converted) {
-        FMOD_STUDIO_PARAMETER_ID paramId;
-        paramId.data2 = static_cast<unsigned int>(converted & 0xFFFFFFFF);
-        paramId.data1 = static_cast<unsigned int>((converted >> 32) & 0xFFFFFFFF);
-        return paramId;
-    }
+	static inline FMOD_STUDIO_PARAMETER_ID ulong_to_fmod_parameter_id(uint64_t converted) {
+		FMOD_STUDIO_PARAMETER_ID paramId;
+		paramId.data2 = static_cast<unsigned int>(converted & 0xFFFFFFFF);
+		paramId.data1 = static_cast<unsigned int>((converted >> 32) & 0xFFFFFFFF);
+		return paramId;
+	}
 
-    static inline bool equals(const FMOD_GUID& first, const FMOD_GUID& second) {
-        return first.Data1 == second.Data1
-        && first.Data2 == second.Data2
-        && first.Data3 == second.Data3
-        && first.Data4[0] == second.Data4[0]
-        && first.Data4[1] == second.Data4[1]
-        && first.Data4[2] == second.Data4[2]
-        && first.Data4[3] == second.Data4[3]
-        && first.Data4[4] == second.Data4[4]
-        && first.Data4[5] == second.Data4[5]
-        && first.Data4[6] == second.Data4[6]
-        && first.Data4[7] == second.Data4[7];
-    }
+	static inline bool equals(const FMOD_GUID& first, const FMOD_GUID& second) {
+		return first.Data1 == second.Data1
+			&& first.Data2 == second.Data2
+			&& first.Data3 == second.Data3
+			&& first.Data4[0] == second.Data4[0]
+			&& first.Data4[1] == second.Data4[1]
+			&& first.Data4[2] == second.Data4[2]
+			&& first.Data4[3] == second.Data4[3]
+			&& first.Data4[4] == second.Data4[4]
+			&& first.Data4[5] == second.Data4[5]
+			&& first.Data4[6] == second.Data4[6]
+			&& first.Data4[7] == second.Data4[7];
+	}
 }// namespace godot
 
 #endif// GODOTFMOD_COMMON_H

--- a/src/studio/fmod_bank.cpp
+++ b/src/studio/fmod_bank.cpp
@@ -6,130 +6,149 @@
 using namespace godot;
 
 void FmodBank::_bind_methods() {
-    ClassDB::bind_method(D_METHOD("get_loading_state"), &FmodBank::get_loading_state);
-    ClassDB::bind_method(D_METHOD("get_bus_count"), &FmodBank::get_bus_count);
-    ClassDB::bind_method(D_METHOD("get_event_description_count"), &FmodBank::get_event_description_count);
-    ClassDB::bind_method(D_METHOD("get_string_count"), &FmodBank::get_string_count);
-    ClassDB::bind_method(D_METHOD("get_VCA_count"), &FmodBank::get_vca_count);
-    ClassDB::bind_method(D_METHOD("get_description_list"), &FmodBank::get_description_list);
-    ClassDB::bind_method(D_METHOD("get_bus_list"), &FmodBank::get_bus_list);
-    ClassDB::bind_method(D_METHOD("get_vca_list"), &FmodBank::get_vca_list);
-    ClassDB::bind_method(D_METHOD("is_valid"), &FmodBank::is_valid);
-    ClassDB::bind_method(D_METHOD("get_godot_res_path"), &FmodBank::get_godot_res_path);
-    ClassDB::bind_method(D_METHOD("get_path"), &FmodBank::get_path);
-    ClassDB::bind_method(D_METHOD("get_guid"), &FmodBank::get_guid_as_string);
+	ClassDB::bind_method(D_METHOD("get_loading_state"), &FmodBank::get_loading_state);
+	ClassDB::bind_method(D_METHOD("get_bus_count"), &FmodBank::get_bus_count);
+	ClassDB::bind_method(D_METHOD("get_event_description_count"), &FmodBank::get_event_description_count);
+	ClassDB::bind_method(D_METHOD("get_string_count"), &FmodBank::get_string_count);
+	ClassDB::bind_method(D_METHOD("get_VCA_count"), &FmodBank::get_vca_count);
+	ClassDB::bind_method(D_METHOD("get_description_list"), &FmodBank::get_description_list);
+	ClassDB::bind_method(D_METHOD("get_bus_list"), &FmodBank::get_bus_list);
+	ClassDB::bind_method(D_METHOD("get_vca_list"), &FmodBank::get_vca_list);
+	ClassDB::bind_method(D_METHOD("is_valid"), &FmodBank::is_valid);
+	ClassDB::bind_method(D_METHOD("get_godot_res_path"), &FmodBank::get_godot_res_path);
+	ClassDB::bind_method(D_METHOD("get_path"), &FmodBank::get_path);
+	ClassDB::bind_method(D_METHOD("get_guid"), &FmodBank::get_guid_as_string);
 }
 
 int FmodBank::get_loading_state() {
-    FMOD_STUDIO_LOADING_STATE state;
+	FMOD_STUDIO_LOADING_STATE state;
 
-    ERROR_CHECK_WITH_REASON(_wrapped->getLoadingState(&state), vformat("Cannot get loading state for bank %s", get_path()));
-    return state;
+	ERROR_CHECK_WITH_REASON(_wrapped->getLoadingState(&state), vformat("Cannot get loading state for bank %s", get_path()));
+	return state;
 }
 
 int FmodBank::get_bus_count() {
-    return buses.size();
+	return buses.size();
 }
 
 int FmodBank::get_event_description_count() {
-    return eventDescriptions.size();
+	return eventDescriptions.size();
 }
 
 int FmodBank::get_vca_count() const {
-    return VCAs.size();
+	return VCAs.size();
 }
 
 int FmodBank::get_string_count() const {
-    int count = -1;
-    ERROR_CHECK_WITH_REASON(_wrapped->getStringCount(&count), vformat("Cannot get string count for bank %s", get_path()));
-    return count;
+	int count = -1;
+	ERROR_CHECK_WITH_REASON(_wrapped->getStringCount(&count), vformat("Cannot get string count for bank %s", get_path()));
+	return count;
 }
 
 Array FmodBank::get_description_list() const {
-    Array array;
-    for (const Ref<FmodEventDescription>& ref : eventDescriptions) {
-        array.append(ref);
-    }
-    return array;
+	Array array;
+	for (const Ref<FmodEventDescription>& ref : eventDescriptions) {
+		array.append(ref);
+	}
+	return array;
 }
 
 Array FmodBank::get_bus_list() const {
-    Array array;
-    for (const Ref<FmodBus>& ref : buses) {
-        array.append(ref);
-    }
-    return array;
+	Array array;
+	for (const Ref<FmodBus>& ref : buses) {
+		array.append(ref);
+	}
+	return array;
 }
 
 Array FmodBank::get_vca_list() const {
-    Array array;
-    for (const Ref<FmodVCA>& ref : VCAs) {
-        array.append(ref);
-    }
-    return array;
+	Array array;
+	for (const Ref<FmodVCA>& ref : VCAs) {
+		array.append(ref);
+	}
+	return array;
 }
 
 void FmodBank::update_bank_data() {
-    load_all_buses();
-    load_all_vca();
-    load_all_event_descriptions();
+	load_all_buses();
+	load_all_vca();
+	load_all_event_descriptions();
 }
 
 void FmodBank::load_all_vca() {
-    FMOD::Studio::VCA* array[MAX_VCA_COUNT];
-    int size = 0;
-    if (ERROR_CHECK_WITH_REASON(_wrapped->getVCAList(array, MAX_VCA_COUNT, &size), vformat("Cannot get VCA list for bank %s", get_path()))) {
-        CHECK_SIZE(MAX_VCA_COUNT, size, VCAs)
-        VCAs.clear();
-        for (int i = 0; i < size; ++i) {
-            Ref<FmodVCA> ref = FmodVCA::create_ref(array[i]);
-            VCAs.push_back(ref);
-        }
-    }
+	int size = 0;
+	FMOD::Studio::VCA** array = nullptr;
+
+	if (ERROR_CHECK_WITH_REASON(_wrapped->getVCACount(&size), vformat("Cannot get num VCA for bank %s", get_path()))) {
+		array = (FMOD::Studio::VCA**)alloca(sizeof(FMOD::Studio::VCA*) * size);
+	}
+
+	if (ERROR_CHECK_WITH_REASON(_wrapped->getVCAList(array, size, &size), vformat("Cannot get VCA list for bank %s", get_path()))) {
+		VCAs.clear();
+		for (int i = 0; i < size; ++i) {
+			Ref<FmodVCA> ref = FmodVCA::create_ref(array[i]);
+			VCAs.push_back(ref);
+		}
+	}
 }
 
 void FmodBank::load_all_buses() {
-    FMOD::Studio::Bus* array[MAX_BUS_COUNT];
-    int size = 0;
-    if (ERROR_CHECK_WITH_REASON(_wrapped->getBusList(array, MAX_BUS_COUNT, &size), vformat("Cannot get bus list for bank %s", get_path()))) {
-        CHECK_SIZE(MAX_BUS_COUNT, size, buses)
-        buses.clear();
-        for (int i = 0; i < size; ++i) {
-            Ref<FmodBus> ref = FmodBus::create_ref(array[i]);
-            buses.push_back(ref);
-        }
-    }
+	int size = 0;
+	FMOD::Studio::Bus** array = nullptr;
+
+	if (ERROR_CHECK_WITH_REASON(_wrapped->getBusCount(&size), vformat("Cannot get num buses for bank %s", get_path()))) {
+		array = (FMOD::Studio::Bus**)alloca(sizeof(FMOD::Studio::Bus*) * size);
+	}
+
+	if (ERROR_CHECK_WITH_REASON(_wrapped->getBusList(array, size, &size), vformat("Cannot get bus list for bank %s", get_path()))) {
+		buses.clear();
+		for (int i = 0; i < size; ++i) {
+
+			if (!array[i] || !array[i]->isValid())
+			{
+				GODOT_LOG_WARNING("Invalid Object. array[i].")
+			}
+
+			Ref<FmodBus> ref = FmodBus::create_ref(array[i]);
+			buses.push_back(ref);
+		}
+	}
 }
 
 void FmodBank::load_all_event_descriptions() {
-    FMOD::Studio::EventDescription* array[MAX_EVENT_DESCRIPTION_COUNT];
-    int size = 0;
-    if (ERROR_CHECK_WITH_REASON(_wrapped->getEventList(array, MAX_EVENT_DESCRIPTION_COUNT, &size), vformat("Cannot get event list for bank %s", get_path()))) {
-        CHECK_SIZE(MAX_EVENT_DESCRIPTION_COUNT, size, Events)
-        eventDescriptions.clear();
-        for (int i = 0; i < size; ++i) {
-            Ref<FmodEventDescription> ref = FmodEventDescription::create_ref(array[i]);
-            eventDescriptions.push_back(ref);
-        }
-    }
+
+	int size = 0;
+	FMOD::Studio::EventDescription** array = nullptr;
+
+	if (ERROR_CHECK_WITH_REASON(_wrapped->getEventCount(&size), vformat("Cannot get num events for bank %s", get_path()))) {
+		array = (FMOD::Studio::EventDescription**)alloca(sizeof(FMOD::Studio::EventDescription*) * size);
+	}
+
+	if (ERROR_CHECK_WITH_REASON(_wrapped->getEventList(array, size, &size), vformat("Cannot get event list for bank %s", get_path()))) {
+		eventDescriptions.clear();
+		for (int i = 0; i < size; ++i) {
+			Ref<FmodEventDescription> ref = FmodEventDescription::create_ref(array[i]);
+			eventDescriptions.push_back(ref);
+		}
+	}
 }
 
 const List<Ref<FmodEventDescription>>& FmodBank::getEventDescriptions() const {
-    return eventDescriptions;
+	return eventDescriptions;
 }
 
 const List<Ref<FmodBus>>& FmodBank::getBuses() const {
-    return buses;
+	return buses;
 }
 
 const List<Ref<FmodVCA>>& FmodBank::getVcAs() const {
-    return VCAs;
+	return VCAs;
 }
 
 const String& FmodBank::get_godot_res_path() const {
-    return _godot_res_path;
+	return _godot_res_path;
 }
 
 FmodBank::~FmodBank() {
-    FmodServer::get_singleton()->unload_bank(_godot_res_path);
+	FmodServer::get_singleton()->unload_bank(_godot_res_path);
 }


### PR DESCRIPTION
Banks were limited to loading a max of 256 events, 64 VCA's and 64 Buses. This was pretty small, especially for events. This removes that limitation and loads all the VCA's, Buses and Events that appear in any Bank. 

Also, in the old implementation, requesting events by GUID would fail for anything but the first 256 events, even though the events exist in the Bank.