### PR TITLE
Check Node validity using locally stored ObjectID

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -44,7 +44,7 @@ jobs:
             shell: pwsh
 
           - name: Ubuntu Editor Compilation
-            os: "ubuntu-20.04"
+            os: "ubuntu-22.04"
             platform: linux
             target: editor
             fmod-executable-suffix: linux.tar.gz
@@ -56,14 +56,14 @@ jobs:
             shell: bash
 
           - name: Ubuntu Debug Compilation
-            os: "ubuntu-20.04"
+            os: "ubuntu-22.04"
             platform: linux
             target: template_debug
             fmod-executable-suffix: linux.tar.gz
             shell: bash
 
           - name: Ubuntu Release Compilation
-            os: "ubuntu-20.04"
+            os: "ubuntu-22.04"
             platform: linux
             target: template_release
             fmod-executable-suffix: linux.tar.gz
@@ -96,7 +96,7 @@ jobs:
             shell: bash
 
           - name: Android Editor Compilation
-            os: "ubuntu-20.04"
+            os: "ubuntu-22.04"
             platform: android
             target: editor
             fmod-executable-suffix: android.tar.gz
@@ -104,7 +104,7 @@ jobs:
             shell: bash
 
           - name: Android Debug Compilation
-            os: "ubuntu-20.04"
+            os: "ubuntu-22.04"
             platform: android
             target: template_debug
             fmod-executable-suffix: android.tar.gz
@@ -112,7 +112,7 @@ jobs:
             shell: bash
 
           - name: Android Release Compilation
-            os: "ubuntu-20.04"
+            os: "ubuntu-22.04"
             platform: android
             target: template_release
             fmod-executable-suffix: android.tar.gz
@@ -179,7 +179,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: "ubuntu-20.04"
+          - os: "ubuntu-22.04"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
             shell: pwsh
 
           - name: Ubuntu Editor Compilation
-            os: "ubuntu-20.04"
+            os: "ubuntu-22.04"
             platform: linux
             target: editor
             fmod-executable-suffix: linux.tar.gz
@@ -57,14 +57,14 @@ jobs:
             shell: bash
 
           - name: Ubuntu Debug Compilation
-            os: "ubuntu-20.04"
+            os: "ubuntu-22.04"
             platform: linux
             target: template_debug
             fmod-executable-suffix: linux.tar.gz
             shell: bash
 
           - name: Ubuntu Release Compilation
-            os: "ubuntu-20.04"
+            os: "ubuntu-22.04"
             platform: linux
             target: template_release
             fmod-executable-suffix: linux.tar.gz
@@ -97,7 +97,7 @@ jobs:
             shell: bash
 
           - name: Android Editor Compilation
-            os: "ubuntu-20.04"
+            os: "ubuntu-22.04"
             platform: android
             target: editor
             fmod-executable-suffix: android.tar.gz
@@ -105,7 +105,7 @@ jobs:
             shell: bash
 
           - name: Android Debug Compilation
-            os: "ubuntu-20.04"
+            os: "ubuntu-22.04"
             platform: android
             target: template_debug
             fmod-executable-suffix: android.tar.gz
@@ -113,7 +113,7 @@ jobs:
             shell: bash
 
           - name: Android Release Compilation
-            os: "ubuntu-20.04"
+            os: "ubuntu-22.04"
             platform: android
             target: template_release
             fmod-executable-suffix: android.tar.gz

--- a/src/fmod_server.cpp
+++ b/src/fmod_server.cpp
@@ -505,7 +505,7 @@ Ref<FmodBank> FmodServer::load_bank(const String& pathToBank, unsigned int flag)
 
 #ifdef DEBUG_ENABLED
     if (!FileAccess::file_exists(pathToBank)) {
-        GODOT_LOG_ERROR(vformat("Cannot load bank at %s", pathToBank));
+        GODOT_LOG_ERROR(vformat("Cannot load bank at %s", pathToBank))
         return {};
     }
 #endif
@@ -516,7 +516,7 @@ Ref<FmodBank> FmodServer::load_bank(const String& pathToBank, unsigned int flag)
 void FmodServer::unload_bank(const String& pathToBank) {
 #ifdef DEBUG_ENABLED
     if (!FileAccess::file_exists(pathToBank)) {
-        GODOT_LOG_ERROR(vformat("Cannot unload bank at %s", pathToBank));
+        GODOT_LOG_ERROR(vformat("Cannot unload bank at %s", pathToBank))
         return;
     }
 #endif

--- a/src/fmod_server.cpp
+++ b/src/fmod_server.cpp
@@ -167,7 +167,7 @@ void FmodServer::init(const Ref<FmodGeneralSettings>& p_settings) {
     advancedSettings.cbSize = sizeof(FMOD_ADVANCEDSETTINGS);
     ERROR_CHECK(coreSystem->getAdvancedSettings(&advancedSettings));
 
-    advancedSettings.randomSeed = static_cast<unsigned int>(std::time(0));// Use time as a seed
+    advancedSettings.randomSeed = static_cast<unsigned int>(std::time(nullptr));// Use time as a seed
     ERROR_CHECK(coreSystem->setAdvancedSettings(&advancedSettings));
 
     FMOD_STUDIO_INITFLAGS studio_init_flags = FMOD_STUDIO_INIT_NORMAL;
@@ -233,13 +233,13 @@ void FmodServer::update() {
     Vector<OneShot*> one_shots_copy = oneShots;
     for (OneShot* oneShot : one_shots_copy) {
 
-        if (!oneShot->instance->is_valid() || is_dead(oneShot->gameObj)) {
+        if (!oneShot->instance->is_valid() || oneShot->wrapper.is_valid()) {
             //We release one-shots when they are started, the event becomes invalid as soon as it ends
             oneShots.erase(oneShot);
             delete oneShot;
             continue;
         }
-        oneShot->instance->set_node_attributes(oneShot->gameObj);
+        oneShot->instance->set_node_attributes(oneShot->wrapper.get_node());
     }
 
     Vector<Ref<FmodEvent>> events_copy = runningEvents;
@@ -273,13 +273,13 @@ void FmodServer::_set_listener_attributes() {
     for (int i = 0; i < systemListenerNumber; ++i) {
         Listener* listener = &listeners[i];
         if (listener->listenerLock) { continue; }
-        if (is_dead(listener->gameObj)) {
-            listener->gameObj = nullptr;
+        if (!listener->wrapper.is_valid()) {
+            listener->wrapper.set_node(nullptr);
             ERROR_CHECK_WITH_REASON(system->setListenerWeight(i, 0), vformat("Cannot set listener %d weight to 0", i));
             continue;
         }
 
-        Node* node {Object::cast_to<Node>(listener->gameObj)};
+        Node* node {listener->wrapper.get_node()};
         if (!node->is_inside_tree()) { return; }
 
         if (auto* ci {Node::cast_to<CanvasItem>(node)}) {
@@ -321,16 +321,16 @@ void FmodServer::set_system_listener_number(int p_listenerNumber) {
     }
 }
 
-void FmodServer::add_listener(int index, Object* game_obj) {
-    if (!is_fmod_valid(game_obj)) { return; }
+void FmodServer::add_listener(int index, Node* game_obj) {
+    if (!NodeWrapper::is_spatial_node(game_obj)) { return; }
     if (index >= 0 && index < systemListenerNumber) {
         Listener* listener = &listeners[index];
-        listener->gameObj = game_obj;
+        listener->wrapper.set_node(game_obj);
         ERROR_CHECK_WITH_REASON(system->setListenerWeight(index, listener->weight),
                                 vformat("Cannot set listener %d weight to %f", index, listener->weight));
         int count = 0;
         for (int i = 0; i < systemListenerNumber; ++i) {
-            if ((&listeners[i])->gameObj != nullptr) count++;
+            if ((&listeners[i])->wrapper.get_node() != nullptr) count++;
         }
         actualListenerNumber = count;
         if (actualListenerNumber > 0) listenerWarning = true;
@@ -339,20 +339,20 @@ void FmodServer::add_listener(int index, Object* game_obj) {
     }
 }
 
-void FmodServer::remove_listener(int index, Object* game_obj) {
+void FmodServer::remove_listener(int index, Node* game_obj) {
     if (index >= 0 && index < systemListenerNumber) {
         Listener* listener = &listeners[index];
 
-        if (listener->gameObj != game_obj) {
+        if (listener->wrapper.get_node() != game_obj) {
             return;
         }
 
-        listener->gameObj = nullptr;
+        listener->wrapper.set_node(nullptr);
         ERROR_CHECK_WITH_REASON(system->setListenerWeight(index, 0),
                     vformat("Cannot set listener %d weight to 0", index));
         int count = 0;
         for (int i = 0; i < systemListenerNumber; ++i) {
-            if ((&listeners[i])->gameObj != nullptr) count++;
+            if ((&listeners[i])->wrapper.get_node() != nullptr) count++;
         }
         actualListenerNumber = count;
         if (actualListenerNumber > 0) listenerWarning = true;
@@ -482,7 +482,7 @@ Object* FmodServer::get_object_attached_to_listener(int index) {
         GODOT_LOG_ERROR("index of listeners must be set between 0 and the number of listeners set")
         return nullptr;
     } else {
-        Object* node = listeners[index].gameObj;
+        Object* node = listeners[index].wrapper.get_node();
         if (!node) { GODOT_LOG_WARNING("No node was set on listener") }
         return node;
     }

--- a/src/fmod_server.h
+++ b/src/fmod_server.h
@@ -35,12 +35,12 @@
 namespace godot {
 
     struct OneShot {
-        Node* gameObj = nullptr;
+        NodeWrapper wrapper;
         Ref<FmodEvent> instance;
     };
 
     struct Listener {
-        Object* gameObj = nullptr;
+        NodeWrapper wrapper;
         bool listenerLock = false;
         float weight = 1.0;
     };
@@ -181,8 +181,8 @@ namespace godot {
         Array get_global_parameter_desc_list();
 
         // LISTENERS
-        void add_listener(int index, Object* game_obj);
-        void remove_listener(int index, Object* game_obj);
+        void add_listener(int index, Node* game_obj);
+        void remove_listener(int index, Node* game_obj);
         void set_system_listener_number(int listenerNumber);
         int get_system_listener_number() const;
         float get_system_listener_weight(int index);
@@ -303,7 +303,8 @@ namespace godot {
             return;
         }
 
-        if (game_obj && !is_fmod_valid(game_obj)) {
+        if (game_obj && !NodeWrapper::is_spatial_node(game_obj)) {
+            GODOT_LOG_ERROR("Invalid Object. A Godot object bound to FMOD has to be either a Node3D or CanvasItem.")
             return;
         }
 
@@ -317,9 +318,7 @@ namespace godot {
         }
 
         if(game_obj){
-            auto* oneShot = new OneShot();
-            oneShot->gameObj = game_obj;
-            oneShot->instance = ref;
+            auto* oneShot = new OneShot {NodeWrapper {game_obj}, ref};
             ref->set_node_attributes(game_obj);
             oneShots.push_back(oneShot);
         }

--- a/src/helpers/common.h
+++ b/src/helpers/common.h
@@ -131,12 +131,12 @@ namespace godot {
 
         void set_node(Node* p_node) {
             if (p_node) {
-                if (!is_spatial_node(p_node)) {
-                    GODOT_LOG_ERROR("Invalid Object. A Godot object bound to FMOD has to be either a Node3D or CanvasItem.")
+                if (is_spatial_node(p_node)) {
+                    node = p_node;
+                    id = p_node->get_instance_id();
                     return;
                 }
-                node = p_node;
-                id = p_node->get_instance_id();
+                GODOT_LOG_ERROR("Invalid Object. A Godot object bound to FMOD has to be either a Node3D or CanvasItem.")
             }
             node = nullptr;
         }

--- a/src/helpers/common.h
+++ b/src/helpers/common.h
@@ -4,10 +4,10 @@
 #include "classes/canvas_item.hpp"
 #include "classes/node3d.hpp"
 #include "fmod_common.h"
-#include <fmod_studio_common.h>
 #include "variant/utility_functions.hpp"
 
 #include <fmod_errors.h>
+#include <fmod_studio_common.h>
 #include <helpers/current_function.h>
 
 #include <godot.hpp>
@@ -112,22 +112,38 @@ public:                                                                  \
 private:
 
 namespace godot {
-    static bool is_dead(Object* node) {
-        if (!node || !UtilityFunctions::is_instance_id_valid(node->get_instance_id())) {
-            return true;
-        }
-        return !Object::cast_to<Node>(node)->is_inside_tree();
-    }
 
-    static bool is_fmod_valid(Object* node) {
-        if (node) {
-            bool ret = Node::cast_to<Node3D>(node) || Node::cast_to<CanvasItem>(node);
-            if (!ret) { GODOT_LOG_ERROR("Invalid Object. A listener has to be either a Node3D or CanvasItem.") }
-            return ret;
+    class NodeWrapper {
+        Node* node {nullptr};
+        ObjectID id;
+
+    public:
+        _FORCE_INLINE_ static bool is_spatial_node(Object* p_object) {
+            return Node::cast_to<Node3D>(p_object) || Node::cast_to<CanvasItem>(p_object);
         }
-        GODOT_LOG_ERROR("Object is null")
-        return false;
-    }
+
+        bool is_valid() {
+            if (!node || !id.is_valid() || !UtilityFunctions::is_instance_id_valid(id)) { return false; }
+            return node->is_inside_tree();
+        }
+
+        Node* get_node() { return node; }
+
+        void set_node(Node* p_node) {
+            if (p_node) {
+                if (!is_spatial_node(p_node)) {
+                    GODOT_LOG_ERROR("Invalid Object. A Godot object bound to FMOD has to be either a Node3D or CanvasItem.")
+                    return;
+                }
+                node = p_node;
+                id = p_node->get_instance_id();
+            }
+            node = nullptr;
+        }
+
+        NodeWrapper() = default;
+        explicit NodeWrapper(Node* p_node) { set_node(p_node); };
+    };
 
     template<class T>
     static inline Ref<T> create_ref() {

--- a/src/studio/fmod_event.cpp
+++ b/src/studio/fmod_event.cpp
@@ -218,7 +218,7 @@ Transform3D FmodEvent::get_3d_attributes() const {
 }
 
 void FmodEvent::set_node_attributes(Node* node) const {
-    if (is_fmod_valid(node) && Object::cast_to<Node>(node)->is_inside_tree()) {
+    if (node->is_inside_tree()) {
         if (auto* ci {Node::cast_to<CanvasItem>(node)}) {
             FMOD_3D_ATTRIBUTES attr = get_3d_attributes_from_transform2d(ci->get_global_transform(), distanceScale);
             ERROR_CHECK(_wrapped->set3DAttributes(&attr));
@@ -230,6 +230,7 @@ void FmodEvent::set_node_attributes(Node* node) const {
             return;
         }
     }
+    GODOT_LOG_ERROR("Invalid Object. A Godot object bound to FMOD has to be either a Node3D or CanvasItem.")
 }
 
 void FmodEvent::set_callback(const Callable& callback, uint32_t p_callback_mask) {


### PR DESCRIPTION
Fix #301

In several parts of FmodServer, we were using Godot objects that could have potentially died since the previous iteration:
- The listeners
- The oneshots
- The callbacks

We normally use the ObjectID to fetch the validity of those objects but we assume the ID was stored locally in the wrapper. In fact it wasn't so everytime we wanted to use it and the object was dead, we were using a dead pointer, hence the crash.