### PR TITLE
Do not apply spatialization when attached mode is off

### DIFF
--- a/demo/low_level_2D/FmodScriptTest.tscn
+++ b/demo/low_level_2D/FmodScriptTest.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=13 format=3 uid="uid://cs8nm6h12whh1"]
 
 [ext_resource type="Script" uid="uid://dn0b4rle1712" path="res://low_level_2D/FmodTest.gd" id="1_oc8v3"]
-[ext_resource type="Texture2D" uid="uid://ddwfplq00r6jt" path="res://icon.png" id="2_mamb7"]
+[ext_resource type="Texture2D" uid="uid://cqukahqq7n5pk" path="res://icon.png" id="2_mamb7"]
 [ext_resource type="Script" uid="uid://cxg2l03odbmwv" path="res://low_level_2D/Emitter.gd" id="3_fx7d3"]
 [ext_resource type="Script" uid="uid://c4p1w0xlxjs4l" path="res://low_level_2D/Listener.gd" id="4_448uv"]
 [ext_resource type="Script" uid="uid://dae10jufdshyv" path="res://low_level_2D/EnterAndLeave.gd" id="5_85yno"]
@@ -146,3 +146,9 @@ offset_bottom = 646.0
 text = "Say welcome"
 script = ExtResource("9_jo4tj")
 welcome_option_button_path = NodePath("../WelcomeOptionButton")
+
+[node name="FmodEventEmitter2D" type="FmodEventEmitter2D" parent="."]
+event_name = "event:/Weapons/Pistol"
+event_guid = "{03c85dcf-c4eb-4094-83c7-7839b5d058e8}"
+attached = false
+autoplay = true

--- a/src/nodes/fmod_event_emitter.h
+++ b/src/nodes/fmod_event_emitter.h
@@ -98,6 +98,7 @@ namespace godot {
     private:
         template<bool is_one_shot> void _play(bool should_start_event);
         void set_space_attribute(const Ref<FmodEvent>& p_event) const;
+        void reset_space_attribute(const Ref<FmodEvent>& p_event) const;
         void _set_parameter_value(Parameter* parameter, const Variant& p_property);
         void apply_parameters();
         void free();
@@ -117,6 +118,11 @@ namespace godot {
     template<class Derived, class NodeType>
     void FmodEventEmitter<Derived, NodeType>::set_space_attribute(const Ref<FmodEvent>& p_event) const {
         static_cast<const Derived*>(this)->set_space_attribute_impl(p_event);
+    }
+
+    template<class Derived, class NodeType>
+    void FmodEventEmitter<Derived, NodeType>::reset_space_attribute(const Ref<FmodEvent>& p_event) const {
+        static_cast<const Derived*>(this)->reset_space_attribute_impl(p_event);
     }
 
     template<class Derived, class NodeType>
@@ -161,7 +167,9 @@ namespace godot {
             }
         }
 
-        if (_attached && _event->is_valid()) { set_space_attribute(_event); }
+        if (_attached && _event->is_valid()) {
+            set_space_attribute(_event);
+        }
     }
 
     template<class Derived, class NodeType>
@@ -255,7 +263,11 @@ namespace godot {
         event->set_volume(_volume);
         apply_parameters();
 
-        set_space_attribute(event);
+        if (_attached) {
+            set_space_attribute(event);
+        } else {
+            reset_space_attribute(event);
+        }
         if (!_programmer_callback_sound_key.is_empty()) {
             event->set_programmer_callback(_programmer_callback_sound_key);
         }

--- a/src/nodes/fmod_event_emitter_2d.cpp
+++ b/src/nodes/fmod_event_emitter_2d.cpp
@@ -6,6 +6,10 @@ void FmodEventEmitter2D::set_space_attribute_impl(const Ref<FmodEvent>& p_event)
     p_event->set_2d_attributes(get_global_transform());
 }
 
+void FmodEventEmitter2D::reset_space_attribute_impl(const Ref<FmodEvent>& p_event) const {
+    p_event->set_2d_attributes(FmodServer::get_singleton()->get_listener_transform2d(0));
+}
+
 void FmodEventEmitter2D::_ready() {
     FmodEventEmitter<FmodEventEmitter2D, Node2D>::_ready();
 }

--- a/src/nodes/fmod_event_emitter_2d.h
+++ b/src/nodes/fmod_event_emitter_2d.h
@@ -13,6 +13,7 @@ namespace godot {
 
     private:
         void set_space_attribute_impl(const Ref<FmodEvent>& p_event) const;
+        void reset_space_attribute_impl(const Ref<FmodEvent>& p_event) const;
         void free_impl();
 
     public:

--- a/src/nodes/fmod_event_emitter_3d.cpp
+++ b/src/nodes/fmod_event_emitter_3d.cpp
@@ -6,6 +6,10 @@ void FmodEventEmitter3D::set_space_attribute_impl(const Ref<FmodEvent>& p_event)
     p_event->set_3d_attributes(get_global_transform());
 }
 
+void FmodEventEmitter3D::reset_space_attribute_impl(const Ref<FmodEvent>& p_event) const {
+    p_event->set_3d_attributes(FmodServer::get_singleton()->get_listener_transform3d(0));
+}
+
 void FmodEventEmitter3D::_ready() {
     FmodEventEmitter<FmodEventEmitter3D, Node3D>::_ready();
 }

--- a/src/nodes/fmod_event_emitter_3d.h
+++ b/src/nodes/fmod_event_emitter_3d.h
@@ -12,6 +12,7 @@ namespace godot {
 
     private:
         void set_space_attribute_impl(const Ref<FmodEvent>& p_event) const;
+        void reset_space_attribute_impl(const Ref<FmodEvent>& p_event) const;
         void free_impl();
 
     public:


### PR DESCRIPTION
There was an issue with `FmodEventEmitter2D` when setting `attached` to `false` because it should not apply spatialization in that case.

This PR fixes that issue.