### PR TITLE
Increase plugin config version to match the current tag 6.0.0

### DIFF
--- a/demo/addons/fmod/plugin.cfg
+++ b/demo/addons/fmod/plugin.cfg
@@ -3,5 +3,5 @@
 name="FMOD GDExtension"
 description="FMOD GDExtension for Godot Engine 4.4"
 author="Utopia-rise, Tristan Grespinet, Pierre-Thomas Meisels"
-version="5.0.5"
+version="6.0.0"
 script="FmodPlugin.gd"


### PR DESCRIPTION
A very small fix 🙂 to keep the plugin version up to date.

I'm actually reading it out in a small script to install the dependencies for the devs in my team, so I actually depend on this.