### PR TITLE
Improve file callback

### DIFF
--- a/src/callback/file_callbacks.h
+++ b/src/callback/file_callbacks.h
@@ -47,7 +47,7 @@ namespace Callbacks {
 
     public:
         void queueReadRequest(FMOD_ASYNCREADINFO* request, ReadPriority priority);
-        void cancelReadRequest(FMOD_ASYNCREADINFO* request);
+        FMOD_RESULT cancelReadRequest(FMOD_ASYNCREADINFO* request);
         void start();
         void finish();
     };


### PR DESCRIPTION
During the investigation regarding #351, I came across minor improvements for the file callback so it's more in line with what FMOD expects ( using their own examples as reference).
They don't fix the issue because the cause is unrelated but I'm still pushing them so we avoid any weird minor side effects in the future:
- Fmod has 3 priorities 0, 50, 100. I moved 50 to be considered "High priority"
- Godot "end of file" returns true when we exactly reach the end of a file, but FMOD only wants to know when we got beyond it (hence checking if the returned size is smaller than the one required).
- Cancel request have to call "done" to confirm they were indeed cancelled.