### PR TITLE
fix: Check directory exists before listing files in it

### DIFF
--- a/src/helpers/files.h
+++ b/src/helpers/files.h
@@ -14,6 +14,11 @@ namespace godot {
         }
 
         Ref<DirAccess> folder_access {DirAccess::open(folder)};
+
+        if (folder_access.is_null()) {
+            return;
+        }
+
         folder_access->list_dir_begin();
         String current_file{folder_access->get_next()};
         while (!current_file.is_empty()) {

--- a/src/resources/fmod_plugins_settings.cpp
+++ b/src/resources/fmod_plugins_settings.cpp
@@ -1,7 +1,12 @@
 #include "fmod_plugins_settings.h"
+
+#include "constants.h"
+
+#include <helpers/common.h>
+
+#include <classes/file_access.hpp>
 #include <classes/project_settings.hpp>
 #include <classes/resource_loader.hpp>
-#include "constants.h"
 
 using namespace godot;
 
@@ -29,6 +34,14 @@ Ref<FmodPluginsSettings> FmodPluginsSettings::get_from_project_settings() {
       FmodPluginsSettings::DEFAULT_RESOURCE_OPTION
     );
     if (resource_path.is_empty()) {
+        Ref<FmodPluginsSettings> settings;
+        settings.instantiate();
+        return settings;
+    }
+
+    if (!FileAccess::file_exists(resource_path)) {
+        GODOT_LOG_WARNING(vformat("Cannot find FmodPluginsSettings at %s", resource_path));
+
         Ref<FmodPluginsSettings> settings;
         settings.instantiate();
         return settings;


### PR DESCRIPTION
I think that's the crash encountered on #360 
We were not checking if a directory exists in `list_files_in_folder` method. So if the user has no plugins settings set or the path in its settings does not exists it crashes.