### PR TITLE
Add compatibility_maximum to avoid Godot engine crashes

### DIFF
--- a/demo/addons/fmod/fmod.gdextension
+++ b/demo/addons/fmod/fmod.gdextension
@@ -1,6 +1,7 @@
 [configuration]
 entry_symbol = "fmod_library_init"
 compatibility_minimum = 4.2
+compatibility_maximum = 4.4
 
 [libraries]
 windows.editor.x86_64 = "res://addons/fmod/libs/windows/libGodotFmod.windows.editor.x86_64.dll"


### PR DESCRIPTION
Without this flag, Godot does not know if this gdextension is compatible and will attempt to load it. On error, Godot just crashes silently.

This is especially important when upgrading to newer Godot versions while the gdextension is active.