### PR TITLE
feat: enable / disable banks exporting per Godot export preset

### DIFF
--- a/src/tools/fmod_editor_export_plugin.cpp
+++ b/src/tools/fmod_editor_export_plugin.cpp
@@ -13,17 +13,22 @@ constexpr const char* FMOD_FILE_EXTENSIONS[4] {".bank", ".ogg", ".mp3", ".wav"};
 constexpr const char* ANDROID_BUILD_DIRS[2] = { "res://android/build", "res:///android/build" };
 
 void FmodEditorExportPlugin::_export_begin(const PackedStringArray& features, bool is_debug, const String& path, uint32_t flags) {
-    PackedStringArray excluded_folders;
-    for (const char* dir : ANDROID_BUILD_DIRS) {
-        excluded_folders.append(dir);
-    }
-    for (const char* extension : FMOD_FILE_EXTENSIONS) {
-        PackedStringArray files;
-        list_files_in_folder(files, "res://", extension, excluded_folders);
-        for (const String& file : files) {
-            GODOT_LOG_VERBOSE(vformat("Adding %s to pck", file));
-            add_file(file, FileAccess::get_file_as_bytes(file), false);
+
+    if (get_option("fmod/auto_export_banks") != Variant(false)) {
+
+        PackedStringArray excluded_folders;
+        for (const char* dir : ANDROID_BUILD_DIRS) {
+            excluded_folders.append(dir);
         }
+        for (const char* extension : FMOD_FILE_EXTENSIONS) {
+            PackedStringArray files;
+            list_files_in_folder(files, "res://", extension, excluded_folders);
+            for (const String& file : files) {
+                GODOT_LOG_VERBOSE(vformat("Adding %s to pck", file));
+                add_file(file, FileAccess::get_file_as_bytes(file), false);
+            }
+        }
+
     }
 
     bool is_windows_export = features.has("windows");
@@ -173,8 +178,29 @@ extern "C" __attribute__((visibility("default"))) __attribute__((used)) uint32_t
     }
 }
 
+
+
 String FmodEditorExportPlugin::_get_name() const {
     return "FmodEditorExportPlugin";
+}
+
+TypedArray<Dictionary> FmodEditorExportPlugin::_get_export_options(const Ref<EditorExportPlatform>& platform) const {
+    TypedArray<Dictionary> options;
+
+    {
+        Dictionary option_dict;
+        Dictionary option;
+        option["name"] = "fmod/auto_export_banks";
+        option["type"] = Variant::BOOL;
+        
+        option_dict["option"] = option;
+        option_dict["default_value"] = true;
+        option_dict["update_visibility"] = true;
+        
+        options.append(option_dict);
+    }
+    
+    return options;
 }
 
 void FmodEditorExportPlugin::_bind_methods() {}

--- a/src/tools/fmod_editor_export_plugin.cpp
+++ b/src/tools/fmod_editor_export_plugin.cpp
@@ -178,8 +178,6 @@ extern "C" __attribute__((visibility("default"))) __attribute__((used)) uint32_t
     }
 }
 
-
-
 String FmodEditorExportPlugin::_get_name() const {
     return "FmodEditorExportPlugin";
 }

--- a/src/tools/fmod_editor_export_plugin.cpp
+++ b/src/tools/fmod_editor_export_plugin.cpp
@@ -11,10 +11,11 @@ using namespace godot;
 
 constexpr const char* FMOD_FILE_EXTENSIONS[4] {".bank", ".ogg", ".mp3", ".wav"};
 constexpr const char* ANDROID_BUILD_DIRS[2] = { "res://android/build", "res:///android/build" };
+constexpr const char* FMOD_AUTO_EXPORT_BANKS_SETTINGS_KEY = "fmod/auto_export_banks";
 
 void FmodEditorExportPlugin::_export_begin(const PackedStringArray& features, bool is_debug, const String& path, uint32_t flags) {
 
-    if (get_option("fmod/auto_export_banks") != Variant(false)) {
+    if (get_option(FMOD_AUTO_EXPORT_BANKS_SETTINGS_KEY) != Variant(false)) {
 
         PackedStringArray excluded_folders;
         for (const char* dir : ANDROID_BUILD_DIRS) {
@@ -188,7 +189,7 @@ TypedArray<Dictionary> FmodEditorExportPlugin::_get_export_options(const Ref<Edi
     {
         Dictionary option_dict;
         Dictionary option;
-        option["name"] = "fmod/auto_export_banks";
+        option["name"] = FMOD_AUTO_EXPORT_BANKS_SETTINGS_KEY;
         option["type"] = Variant::BOOL;
         
         option_dict["option"] = option;

--- a/src/tools/fmod_editor_export_plugin.h
+++ b/src/tools/fmod_editor_export_plugin.h
@@ -4,7 +4,7 @@
 #define GODOTFMOD_FMOD_EDITOR_EXPORT_PLUGIN_H
 
 #include <resources/fmod_plugins_settings.h>
-#include <godot_cpp/classes/editor_export_platform.hpp> 
+#include <godot_cpp/classes/editor_export_platform.hpp>
 #include <classes/editor_export_plugin.hpp>
 
 namespace godot {

--- a/src/tools/fmod_editor_export_plugin.h
+++ b/src/tools/fmod_editor_export_plugin.h
@@ -4,7 +4,7 @@
 #define GODOTFMOD_FMOD_EDITOR_EXPORT_PLUGIN_H
 
 #include <resources/fmod_plugins_settings.h>
-
+#include <godot_cpp/classes/editor_export_platform.hpp> 
 #include <classes/editor_export_plugin.hpp>
 
 namespace godot {
@@ -14,6 +14,7 @@ namespace godot {
     public:
         void _export_begin(const PackedStringArray &features, bool is_debug, const String &path, uint32_t flags) override;
         String _get_name() const override;
+        virtual TypedArray<Dictionary> _get_export_options(const Ref<EditorExportPlatform>& platform) const override;
 
         static void _bind_methods();
 


### PR DESCRIPTION
This change adds an option per Godot export preset to enable or disable exporting the banks automatically. Exporting is enabled by default so it doesn't change anything for existing configurations.

I believe this improves workflows under certain conditions especially in projects with multiple export plugins and/or multiple export presets for the same project. 

<img width="969" height="668" alt="s" src="https://github.com/user-attachments/assets/d62d6e55-a92d-4d84-8df7-b3f183c28e87" />
