### PR TITLE
Fix rare crash during export when FMOD events are incorrectly setup by user

### DIFF
--- a/src/nodes/fmod_event_emitter.h
+++ b/src/nodes/fmod_event_emitter.h
@@ -727,7 +727,9 @@ namespace godot {
         if (!parameter) { return false; }
 
         if (parts.size() == 1) {
-            r_property = _get_parameter_description(*parameter)->get_default_value();
+            Ref<FmodParameterDescription> desc {_get_parameter_description(*parameter)};
+            if (desc.is_null()) { return false; }
+            r_property = desc->get_default_value();
             return true;
         }
 
@@ -750,6 +752,10 @@ namespace godot {
             const String& parameter_name {parameter.name};
 
             Ref<FmodParameterDescription> parameter_description{_get_parameter_description(parameter) };
+            if (parameter_description.is_null()) {
+                // Skip parameters that cannot be resolved (e.g., missing or stale IDs)
+                continue;
+            }
 
             const float parameter_min_value {parameter_description->get_minimum()};
             const float parameter_max_value {parameter_description->get_maximum()};


### PR DESCRIPTION
During export, Godot Engine itself can experience a crash due to this extension in case some of the FMOD events are incorrectly set up inside the editor. The current implementation assumes that the editor always is set up correctly, however, there can be situations where it isn't.

<img width="3130" height="1602" alt="Screenshot 2025-09-28 124458" src="https://github.com/user-attachments/assets/8dc53948-7cd9-4839-a517-13c1a15c4871" />

Note: ideally, during export, we should also show warnings to the user for any event that we could not resolve properly (which currently does not yet happen) but I am looking into a separate PR for this.