### PR TITLE
Call `mixerSuspend` and `mixerResume` when moving to/from background on iOS

### DIFF
--- a/demo/addons/fmod/FmodManager.gd
+++ b/demo/addons/fmod/FmodManager.gd
@@ -17,3 +17,8 @@ func _process(delta):
 	
 func _notification(what):
 	FmodServer.notification(what)
+
+	if OS.has_feature("ios"):
+		match what:
+			NOTIFICATION_APPLICATION_FOCUS_OUT: FmodServer.mixer_suspend()
+			NOTIFICATION_APPLICATION_FOCUS_IN: FmodServer.mixer_resume()

--- a/demo/addons/fmod/FmodManager.gd
+++ b/demo/addons/fmod/FmodManager.gd
@@ -18,7 +18,7 @@ func _process(delta):
 func _notification(what):
 	FmodServer.notification(what)
 
-	if OS.has_feature("ios"):
+	if OS.has_feature("mobile"):
 		match what:
 			NOTIFICATION_APPLICATION_FOCUS_OUT: FmodServer.mixer_suspend()
 			NOTIFICATION_APPLICATION_FOCUS_IN: FmodServer.mixer_resume()

--- a/src/fmod_server.cpp
+++ b/src/fmod_server.cpp
@@ -132,6 +132,8 @@ void FmodServer::_bind_methods() {
     ClassDB::bind_method(D_METHOD("unpause_all_events"), &FmodServer::unpause_all_events);
     ClassDB::bind_method(D_METHOD("mute_all_events"), &FmodServer::mute_all_events);
     ClassDB::bind_method(D_METHOD("unmute_all_events"), &FmodServer::unmute_all_events);
+    ClassDB::bind_method(D_METHOD("mixer_suspend"), &FmodServer::mixer_suspend);
+    ClassDB::bind_method(D_METHOD("mixer_resume"), &FmodServer::mixer_resume);
 
     ClassDB::bind_method(D_METHOD("create_sound_instance", "path"), &FmodServer::create_sound_instance);
     REGISTER_ALL_CONSTANTS
@@ -840,6 +842,14 @@ void FmodServer::unmute_all_events() {
         FMOD::Studio::Bus* masterBus = nullptr;
         if (ERROR_CHECK(system->getBus("bus:/", &masterBus))) { masterBus->setMute(false); }
     }
+}
+
+void FmodServer::mixer_suspend() {
+    ERROR_CHECK(coreSystem->mixerSuspend());
+}
+
+void FmodServer::mixer_resume() {
+    ERROR_CHECK(coreSystem->mixerResume());
 }
 
 Ref<FmodFile> FmodServer::load_file_as_sound(const String& path) {

--- a/src/fmod_server.h
+++ b/src/fmod_server.h
@@ -260,6 +260,8 @@ namespace godot {
         void unpause_all_events();
         void mute_all_events();
         void unmute_all_events();
+        void mixer_suspend();
+        void mixer_resume();
         void wait_for_all_loads();
 
     protected:


### PR DESCRIPTION
Addresses https://github.com/utopia-rise/fmod-gdextension/issues/401