### PR TITLE
Remove `debug_symbols` flag from compilation docs

### DIFF
--- a/docs/src/doc/advanced/1-compiling.md
+++ b/docs/src/doc/advanced/1-compiling.md
@@ -30,8 +30,10 @@ Sconstruct.
 In order to compile you should run `scons` command, as for all gdextension projects.
 
 ```
-scons platform=<macos|linux|windows|ios|android> target=<editor|template_debug|template_release> debug_symbols<yes|no> --jobs=<desired number of threads>
+scons platform=<macos|linux|windows|ios|android> target=<editor|template_debug|template_release> --jobs=<desired number of threads>
 ```
+
+If `target` is `editor` or `template_debug`, debug symbols will be generated.
 
 ### Additional Instructions
 


### PR DESCRIPTION
The flag isn't recognized, and debug symbols are automatically added if the target is `editor` or `template_debug`