### PR TITLE
Fix compiling with GCC 13+

### DIFF
--- a/src/helpers/common.h
+++ b/src/helpers/common.h
@@ -9,6 +9,7 @@
 #include <fmod_errors.h>
 #include <fmod_studio_common.h>
 #include <helpers/current_function.h>
+#include <cstdio>
 
 #include <godot.hpp>
 #include <variant/utility_functions.hpp>


### PR DESCRIPTION
Per [the porting docs](https://gcc.gnu.org/gcc-13/porting_to.html) `cstdio` is no longer implicitly included from GCC 13 on. Tested with GCC 15.