### PR TITLE
Updated .gitignore to exclude Visual Studio solution files generated by CMake + Moved cmake minimum required definition after project definition 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,11 @@ _deps
 # External projects
 *-prefix/
 
+### Visual Studio Generated Files ###
+*.vcxproj
+*.vcxproj.filters
+*.sln
+
 ### SCons ###
 # for projects that use SCons for building: http://http://www.scons.org/
 .sconsign.dblite

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(GodotFmod)
 cmake_minimum_required(VERSION 3.6)
+project(GodotFmod)
 
 set(GODOT_GDEXTENSION_DIR godot-cpp/gdextension/ CACHE STRING "Path to GDExtension interface header directory")
 set(CPP_BINDINGS_PATH godot-cpp/ CACHE STRING "Path to C++ bindings")


### PR DESCRIPTION
[0148491]
Added the following patterns:

    *.sln
    *.vcxproj
    *.vcxproj.filters

Since users can generate VS solutions with `cmake -G "Visual Studio 17 2022"` (or other versions), these generated files shouldn't be tracked in version control. This prevents unnecessary commits and potential merge conflicts from IDE-specific generated files.

--------------------------------------------------------------
[efa5784]
Changes on `CMakeLists.txt `fixes this warning message:

```
CMake Warning (dev) at CMakeLists.txt:1 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.|
```
