### PR TITLE
Initialize to empty path if `.strings.bank` not loaded

### DIFF
--- a/src/fmod_server.h
+++ b/src/fmod_server.h
@@ -289,7 +289,12 @@ namespace godot {
     template<FmodServer::EventIdentifierType parameter_type>
     Ref<FmodEvent> FmodServer::_create_event_instance(const EventIdentifier& identifier) {
         FMOD::Studio::EventInstance* eventInstance = nullptr;
-        ERROR_CHECK(fetch_event_description<parameter_type>(identifier)->get_wrapped()->createInstance(&eventInstance));
+        auto f = fetch_event_description<parameter_type>(identifier);
+        if (!f.is_valid()) {
+            // If not valid, we already throw a warning in the cache in debug builds
+            return {};
+        }
+        ERROR_CHECK(f->get_wrapped()->createInstance(&eventInstance));
 
         Ref<FmodEvent> ref = FmodEvent::create_ref(eventInstance);
         if (ref.is_null() || !ref->is_valid()) {
@@ -306,6 +311,9 @@ namespace godot {
     template<FmodServer::EventIdentifierType parameter_type>
     void FmodServer::_play_one_shot(const FmodServer::EventIdentifier& identifier, Node* game_obj, const Dictionary& parameters) {
         Ref<FmodEventDescription> desc =  fetch_event_description<parameter_type>(identifier);
+        if (!desc.is_valid()) {
+            return;
+        }
         if (!desc->is_one_shot()){
             GODOT_LOG_WARNING(desc->get_path() + " is not a OneShot event.")
             return;

--- a/src/helpers/common.h
+++ b/src/helpers/common.h
@@ -67,7 +67,7 @@ public:                                                                  \
             ref.instantiate();                                           \
             ref->_wrapped = wrapped;                                     \
             char path[MAX_PATH_SIZE];                                    \
-            ERROR_CHECK(wrapped->getPath(path, MAX_PATH_SIZE, nullptr)); \
+            ERROR_CHECK_WITH_REASON(wrapped->getPath(path, MAX_PATH_SIZE, nullptr), "Could not find path. It is likely that .strings.bank has not been loaded."); \
             ERROR_CHECK(wrapped->getID(&ref->_guid));                    \
             ref->_path = String(path);                                   \
         }                                                                \

--- a/src/helpers/common.h
+++ b/src/helpers/common.h
@@ -68,9 +68,16 @@ public:                                                                  \
             ref.instantiate();                                           \
             ref->_wrapped = wrapped;                                     \
             char path[MAX_PATH_SIZE];                                    \
-            ERROR_CHECK(wrapped->getPath(path, MAX_PATH_SIZE, nullptr)); \
+            /*  FMOD_ERR_EVENT_NOTFOUND is returned for any getPath: https://www.fmod.com/docs/2.03/api/core-api-common.html#fmod_err_event_notfound */ \
+            FMOD_RESULT res = wrapped->getPath(path, MAX_PATH_SIZE, nullptr);\
+            if (res == FMOD_ERR_EVENT_NOTFOUND) {                        \
+                ref->_path = String();                                   \
+            } else {                                                     \
+                /* Handle other error cases */                           \
+                ERROR_CHECK(res);                                        \
+                ref->_path = String(path);                               \
+            }                                                            \
             ERROR_CHECK(wrapped->getID(&ref->_guid));                    \
-            ref->_path = String(path);                                   \
         }                                                                \
         return ref;                                                      \
     }                                                                    \


### PR DESCRIPTION
As a follow up to #428, an error/warning message would be useful here to help people in situations like mine diagnose the problem more easily.

Since not everyone might want to load in strings, happy to make this a warning instead; also happy to move this message to more bus/event specific loading code. Let me know what would work best.