### PR TITLE
Fix formatting in user guide for audio drivers

### DIFF
--- a/docs/src/doc/user-guide/8-other-low-level-examples.md
+++ b/docs/src/doc/user-guide/8-other-low-level-examples.md
@@ -82,7 +82,7 @@ By default, FMOD will use the primary audio output device as determined by the o
 Here, `get_available_drivers()` returns an Array which contains a Dictionary for every audio driver found. Each Dictionary contains fields such as the name, sample rate
 and speaker config of the respective driver. Most importantly, it contains the id for that driver.
 
- ```gdscript
+```gdscript
 # retrieve all available audio drivers
 var drivers = FmodServer.get_available_drivers()
  # change the audio driver


### PR DESCRIPTION
There was a space in line 85 before the gdscript block and this was bugging the webpage.

<img width="871" height="728" alt="image" src="https://github.com/user-attachments/assets/3591a836-6b65-45ec-9974-866582caef0c" />
