### PR TITLE
Add getDSPClock() method and ChannelGroup class

### DIFF
--- a/docs/src/doc/advanced/1-compiling.md
+++ b/docs/src/doc/advanced/1-compiling.md
@@ -1,6 +1,6 @@
 # Compiling from sources
 
-Clone project with `--recurse_submodules`.
+Clone project with `--recurse-submodules`.
 
 ## Typical Project structure
 

--- a/src/core/fmod_channel_group.cpp
+++ b/src/core/fmod_channel_group.cpp
@@ -1,0 +1,25 @@
+#include "fmod_channel_group.h"
+
+#include "helpers/common.h"
+
+using namespace godot;
+
+void FmodChannelGroup::_bind_methods() {
+    ClassDB::bind_method(D_METHOD("get_dsp_clock"), &FmodChannelGroup::get_dsp_clock);
+    ClassDB::bind_method(D_METHOD("get_parent_dsp_clock"), &FmodChannelGroup::get_parent_dsp_clock);
+}
+
+
+uint64_t FmodChannelGroup::get_dsp_clock() const {
+    unsigned long long dspclock = 0;
+    unsigned long long parentclock = 0;
+    ERROR_CHECK(_wrapped->getDSPClock(&dspclock, &parentclock));
+    return (uint64_t) dspclock; // godot does not support unsigned ints?
+}
+
+uint64_t FmodChannelGroup::get_parent_dsp_clock() const {
+    unsigned long long dspclock = 0;
+    unsigned long long parentclock = 0;
+    ERROR_CHECK(_wrapped->getDSPClock(&dspclock, &parentclock));
+    return (uint64_t) parentclock; // godot does not support unsigned ints?
+}

--- a/src/core/fmod_channel_group.h
+++ b/src/core/fmod_channel_group.h
@@ -1,0 +1,32 @@
+#ifndef GODOTFMOD_FMOD_CHANNEL_GROUP_H
+#define GODOTFMOD_FMOD_CHANNEL_GROUP_H
+
+#include "classes/ref_counted.hpp"
+#include "fmod.hpp"
+
+namespace godot {
+    class FmodChannelGroup : public RefCounted {
+        GDCLASS(FmodChannelGroup, RefCounted);
+
+        FMOD::ChannelGroup* _wrapped = nullptr;
+
+    public:
+        inline static Ref<FmodChannelGroup> create_ref(FMOD::ChannelGroup* wrapped) {
+            Ref<FmodChannelGroup> ref;
+            if (wrapped) {
+                ref.instantiate();
+                ref->_wrapped = wrapped;
+                wrapped->setUserData(ref.ptr());
+            }
+            return ref;
+        }
+
+        uint64_t get_dsp_clock() const;
+        uint64_t get_parent_dsp_clock() const;
+
+    protected:
+        static void _bind_methods();
+    };
+}// namespace godot
+
+#endif// GODOTFMOD_FMOD_CHANNEL_GROUP_H

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -78,6 +78,7 @@ void initialize_fmod_module(ModuleInitializationLevel p_level) {
         // Core
         ClassDB::register_class<FmodSound>();
         ClassDB::register_class<FmodFile>();
+        ClassDB::register_class<FmodChannelGroup>();
 
         // Studio
         ClassDB::register_class<FmodBank>();

--- a/src/studio/fmod_event.cpp
+++ b/src/studio/fmod_event.cpp
@@ -40,6 +40,7 @@ void FmodEvent::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_programmer_callback_sound_key"), &FmodEvent::get_programmers_callback_sound_key);
     ClassDB::bind_method(D_METHOD("is_valid"), &FmodEvent::is_valid);
     ClassDB::bind_method(D_METHOD("release"), &FmodEvent::release);
+    ClassDB::bind_method(D_METHOD("get_channel_group"), &FmodEvent::get_channel_group);
 
     ADD_PROPERTY(PropertyInfo(Variant::BOOL, "paused",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_paused", "get_paused");
     ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pitch",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_pitch", "get_pitch");
@@ -254,6 +255,18 @@ const String& FmodEvent::get_programmers_callback_sound_key() const {
 
 void FmodEvent::set_distance_scale(float scale){
     distanceScale = scale;
+}
+
+Ref<FmodChannelGroup> FmodEvent::get_channel_group() const {
+    FMOD::ChannelGroup* channel_group = nullptr;
+    ERROR_CHECK_WITH_REASON(_wrapped->getChannelGroup(&channel_group), vformat("Cannot get ChannelGroup"));
+
+    if (channel_group) {
+        Ref<FmodChannelGroup> ref = FmodChannelGroup::create_ref(channel_group);
+        return ref;
+    }
+
+    return {};
 }
 
 FmodEvent::~FmodEvent() {

--- a/src/studio/fmod_event.h
+++ b/src/studio/fmod_event.h
@@ -4,6 +4,7 @@
 #include "classes/ref_counted.hpp"
 #include "fmod_studio.hpp"
 #include "helpers/common.h"
+#include "core/fmod_channel_group.h"
 
 namespace godot {
     class FmodEvent : public RefCounted {
@@ -55,6 +56,7 @@ namespace godot {
         void set_programmer_callback(const String& p_programmers_callback_sound_key);
         const String& get_programmers_callback_sound_key() const;
         void set_distance_scale(float scale);
+        Ref<FmodChannelGroup> get_channel_group() const;
 
     protected:
         static void _bind_methods();


### PR DESCRIPTION
For a personal project of mine I needed the getDSPClock() function on a ChannelControl in FMOD's core API.
In my use case I had to get this from an EventInstance.getChannelGroup(), which returns a ChannelGroup which inherits ChannelControl's methods.

For this I added a ChannelGroup Class in the core/ subdirectory, which implements only the getDSPClock function that I needed. Anyone is welcome to implement more functions.
I added the getChannelGroup to FmodEvent, so I can retreive a ChannelGroup.

I made this for myself, but I made the PR if there is interest in merging this upstream just in case.

(I also fixed a spelling error in the documentation, this is unrelated to the rest of the PR, sorry for adding this here too)