### PR TITLE
Fix event emitter autoplay in editor

### DIFF
--- a/src/nodes/fmod_event_emitter.h
+++ b/src/nodes/fmod_event_emitter.h
@@ -448,6 +448,10 @@ namespace godot {
         _event_name = name;
         _event_guid = event_guid;
 
+#ifdef TOOLS_ENABLED
+        if (Engine::get_singleton()->is_editor_hint()) { return; }
+#endif
+
         _stop_and_restart_if_autoplay();
     }
 
@@ -466,6 +470,10 @@ namespace godot {
 
         _event_guid = event_guid;
         _event_name = FmodServer::get_singleton()->get_event_path_internal(_event_guid);
+
+#ifdef TOOLS_ENABLED
+        if (Engine::get_singleton()->is_editor_hint()) { return; }
+#endif
 
         _stop_and_restart_if_autoplay();
     }


### PR DESCRIPTION
I found if you update `fmod_event` in FmodEventEmitter Node when `autoplay` is true, the selected fmod event will be played and there is no way to stop it. Looks like we forget adding editor guards here.